### PR TITLE
(feat) Add ability to retrieve encounter type and default to `unknown` encounter role

### DIFF
--- a/src/components/encounter/ohri-encounter-form.tsx
+++ b/src/components/encounter/ohri-encounter-form.tsx
@@ -27,6 +27,7 @@ import { getPreviousEncounter, saveEncounter } from '../../api/api';
 import { scrollIntoView } from '../../utils/ohri-sidebar';
 import { useEncounter } from '../../hooks/useEncounter';
 import { useInitialValues } from '../../hooks/useInitialValues';
+import { useEncounterRole } from '../../hooks/useEncounterRole';
 
 interface OHRIEncounterFormProps {
   formJson: OHRIFormSchema;
@@ -92,6 +93,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
     }),
     [encounter, encounterDate, form?.encounter, location, patient, previousEncounter, sessionMode],
   );
+  const { encounterRole } = useEncounterRole();
 
   const flattenedFields = useMemo(() => {
     const flattenedFieldsTemp = [];
@@ -372,7 +374,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
           ...encounterForSubmission.encounterProviders,
           {
             provider: provider,
-            encounterRole: '240b26f9-dd88-4172-823d-4a8bfeb7841f',
+            encounterRole: encounterRole?.uuid,
           },
         ];
       }
@@ -386,7 +388,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
         encounterProviders: [
           {
             provider: provider,
-            encounterRole: '240b26f9-dd88-4172-823d-4a8bfeb7841f',
+            encounterRole: encounterRole?.uuid,
           },
         ],
         obs: obsForSubmission,

--- a/src/hooks/useEncounterRole.tsx
+++ b/src/hooks/useEncounterRole.tsx
@@ -1,0 +1,15 @@
+import { OpenmrsResource, openmrsFetch } from '@openmrs/esm-framework';
+import useSWRImmutable from 'swr/immutable';
+
+export function useEncounterRole() {
+  const { data, error, isLoading } = useSWRImmutable<{ data: { results: Array<OpenmrsResource> } }, Error>(
+    '/ws/rest/v1/encounterrole?v=custom:(uuid,display,name)',
+    openmrsFetch,
+  );
+  const clinicalEncounterRole = data?.data.results.find(encounterRole => encounterRole.name === 'Clinician');
+
+  if (clinicalEncounterRole) {
+    return { encounterRole: clinicalEncounterRole, error, isLoading };
+  }
+  return { encounterRole: data?.data.results[0], error, isLoading };
+}


### PR DESCRIPTION
### What does this PR do?

At the moment the `hard` code value for encounterRole is `Clinician` for some implementors this might be missing. I have added the ability to retrieve the `encounterRole` and add preference to `Clinician` as the default value if present. In its absence the `UnKnown` encounterRole is picked.

@denniskigen @samuelmale @pirupius @larslemos What are your thoughts on this approach.