### PR TITLE
(feat) Add optional version property to OHRIFormSchema interface

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -71,6 +71,7 @@ export interface OHRIFormSchema {
   formOptions?: {
     usePreviousValueDisabled: boolean;
   };
+  version?: string;
 }
 
 export interface OHRIFormPage {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Adds an optional `version` property to the OHRIFormSchema interface. This should allow a user building a schema using the O3 Form Builder to be able to specify a version number directly in their JSON schema.
