### PR TITLE
(fix) Refactor `useWorkspaceLayout` hook to properly support arbitrary workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "lodash-es": "^4.17.15",
     "moment": "^2.29.1",
     "react-anchor-link-smooth-scroll": "^1.0.12",
-    "react-error-boundary": "3.1.4",
     "react-markdown": "^7.1.0",
     "react-scroll": "^1.8.2",
     "react-test-renderer": "^16.9.0",
@@ -51,6 +50,7 @@
     "@openmrs/esm-framework": "4.x",
     "dayjs": "^1.8.16",
     "react": "^18.2.0",
+    "react-error-boundary": "4.x",
     "react-i18next": "11.x",
     "rxjs": "6.x"
   },
@@ -89,6 +89,7 @@
     "prettier": "^1.18.2",
     "pretty-quick": "^1.11.1",
     "react": "^18.2.0",
+    "react-error-boundary": "^4.0.3",
     "react-i18next": "^11.18.1",
     "rxjs": "^6.6.3",
     "swc-loader": "^0.2.3",

--- a/src/components/encounter/ohri-encounter-form.tsx
+++ b/src/components/encounter/ohri-encounter-form.tsx
@@ -567,6 +567,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
               setSelectedPage={setSelectedPage}
               handlers={handlers}
               workspaceLayout={workspaceLayout}
+              setIsLoadingFormDependencies={setIsLoadingFormDependencies}
               isSubmitting
             />
           );

--- a/src/hooks/useWorkspaceLayout.ts
+++ b/src/hooks/useWorkspaceLayout.ts
@@ -5,11 +5,12 @@ import { useLayoutEffect, useState } from 'react';
  */
 export function useWorkspaceLayout(rootRef): 'minimized' | 'maximized' {
   const [layout, setLayout] = useState<'minimized' | 'maximized'>('minimized');
+  const TABLET_MAX = 1023;
 
   useLayoutEffect(() => {
     const handleResize = () => {
       const containerWidth = rootRef.current?.parentElement?.offsetWidth;
-      setLayout(containerWidth >= 1000 ? 'maximized' : 'minimized');
+      containerWidth && setLayout(containerWidth > TABLET_MAX ? 'maximized' : 'minimized');
     };
     handleResize();
     const resizeObserver = new ResizeObserver(entries => {

--- a/src/hooks/useWorkspaceLayout.ts
+++ b/src/hooks/useWorkspaceLayout.ts
@@ -1,20 +1,27 @@
-import { useLayoutType } from '@openmrs/esm-framework';
-import { useEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 
-export function useWorkspaceLayout(ref): 'minimized' | 'maximized' {
-  const [mode, setMode] = useState<'minimized' | 'maximized'>('maximized');
-  const layout = useLayoutType();
+/**
+ * This hook evaluates the layout of the current workspace based on the width of the container element
+ */
+export function useWorkspaceLayout(rootRef): 'minimized' | 'maximized' {
+  const [layout, setLayout] = useState<'minimized' | 'maximized'>('minimized');
 
-  useEffect(() => {
-    if (ref?.current) {
-      const width = ref.current.offsetWidth;
-      if (layout.endsWith('desktop') && width < 1000) {
-        setMode('minimized');
-      } else {
-        setMode('maximized');
-      }
-    }
-  }, [ref?.current, ref?.current?.offsetWidth, layout]);
+  useLayoutEffect(() => {
+    const handleResize = () => {
+      const containerWidth = rootRef.current?.parentElement?.offsetWidth;
+      setLayout(containerWidth >= 1000 ? 'maximized' : 'minimized');
+    };
+    handleResize();
+    const resizeObserver = new ResizeObserver(entries => {
+      handleResize();
+    });
 
-  return mode;
+    resizeObserver.observe(rootRef.current?.parentElement);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [rootRef]);
+
+  return layout;
 }

--- a/src/ohri-form.component.test.tsx
+++ b/src/ohri-form.component.test.tsx
@@ -31,6 +31,7 @@ const patientUUID = '8673ee4f-e2ab-4077-ba55-4980f408773e';
 const mockOpenmrsFetch = jest.fn();
 const formsResourcePath = when((url: string) => url.includes('/ws/rest/v1/form/'));
 const clobdataResourcePath = when((url: string) => url.includes('/ws/rest/v1/clobdata/'));
+global.ResizeObserver = require('resize-observer-polyfill');
 when(mockOpenmrsFetch)
   .calledWith(formsResourcePath)
   .mockReturnValue({ data: demoHtsOpenmrsForm });

--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -16,7 +16,7 @@ import { OHRIFormSchema, SessionMode, OHRIFormPage as OHRIFormPageProps } from '
 import OHRIFormSidebar from './components/sidebar/ohri-form-sidebar.component';
 import { OHRIEncounterForm } from './components/encounter/ohri-encounter-form';
 import { useWorkspaceLayout } from './hooks/useWorkspaceLayout';
-import { Button } from '@carbon/react';
+import { Button, ButtonSet } from '@carbon/react';
 import ReactMarkdown from 'react-markdown';
 import { PatientBanner } from './components/patient-banner/patient-banner.component';
 import LoadingIcon from './components/loaders/loading.component';
@@ -302,7 +302,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                     />
                   </div>
                   {workspaceLayout == 'minimized' && (
-                    <div className={styles.minifiedButtons}>
+                    <ButtonSet className={styles.minifiedButtons}>
                       <Button
                         kind="secondary"
                         onClick={() => {
@@ -311,12 +311,10 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                         }}>
                         {mode == 'view' ? 'Close' : 'Cancel'}
                       </Button>
-                      {mode != 'view' && (
-                        <Button type="submit" disabled={isSubmitting}>
-                          Save
-                        </Button>
-                      )}
-                    </div>
+                      <Button type="submit" disabled={mode == 'view' || isSubmitting}>
+                        Save
+                      </Button>
+                    </ButtonSet>
                   )}
                 </div>
               </div>

--- a/src/ohri-form.scss
+++ b/src/ohri-form.scss
@@ -42,12 +42,6 @@
   margin-bottom: 0px !important;
 }
 
-@media (max-width: 768px) {
-  .ohriFormContainer {
-    height: 100vh;
-  }
-}
-
 .minifiedButtons {
   width: 100%;
   height: 63.5px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2916,7 +2916,7 @@ __metadata:
     pretty-quick: ^1.11.1
     react: ^18.2.0
     react-anchor-link-smooth-scroll: ^1.0.12
-    react-error-boundary: 3.1.4
+    react-error-boundary: ^4.0.3
     react-i18next: ^11.18.1
     react-markdown: ^7.1.0
     react-scroll: ^1.8.2
@@ -2936,6 +2936,7 @@ __metadata:
     "@openmrs/esm-framework": 4.x
     dayjs: ^1.8.16
     react: ^18.2.0
+    react-error-boundary: 4.x
     react-i18next: 11.x
     rxjs: 6.x
   languageName: unknown
@@ -13540,14 +13541,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-error-boundary@npm:3.1.4":
-  version: 3.1.4
-  resolution: "react-error-boundary@npm:3.1.4"
+"react-error-boundary@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "react-error-boundary@npm:4.0.3"
   dependencies:
     "@babel/runtime": ^7.12.5
   peerDependencies:
     react: ">=16.13.1"
-  checksum: f36270a5d775a25c8920f854c0d91649ceea417b15b5bc51e270a959b0476647bb79abb4da3be7dd9a4597b029214e8fe43ea914a7f16fa7543c91f784977f1b
+  checksum: 50813803d3f03eb2ca07c1250a4a001ffe054f5b3f49b15ea5f0a4e1108f549bc7d8def15db51d518516997d34cebc663f4276246301b4a40a72e83a784f5c38
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR refactors the implementation of useWorkspaceLayout to better support arbitrary workspaces and ensure better form responsiveness. The updated implementation eliminates the funkiness present in the current version. Additionally, the "react-error-boundary" library has been added as a shared dependency, as it is being used by multiple MFs.

## Screenshots
<!-- Required if you are making UI changes. -->

OHRI Form render workspace:

![2023-04-03 20-39-21 2023-04-03 20_40_51](https://user-images.githubusercontent.com/26084581/229586201-41a5e53a-c0b7-49b8-b332-33b9c00d00d2.gif)


Patient Chart workspace:

![2023-04-03 19-59-58 2023-04-03 20_28_07](https://user-images.githubusercontent.com/26084581/229583484-554cf651-42b0-489d-9be0-b25e7beed156.gif)


Known issues:
1. If you were observant enough with the patient chart demo, whenever the container breakpoint is reached (< 1000), the banner disappears and the primary controls get to the bottom, when we decrease the viewport by a few more pixels the sidebar drops to the bottom creating more room for the container hence it switches back to "maximized" mode. When we further shrink the viewport the two get in harmony. 
2. The primary form controls at the bottom disappear within smaller viewports (This is unrelated to changes in this PR)

I will be fixing these issues in a follow-up PR
