### PR TITLE
(fix) fix failing obs-group and repeat component due to `undefined` bug

### DIFF
--- a/src/components/group/ohri-obs-group.component.tsx
+++ b/src/components/group/ohri-obs-group.component.tsx
@@ -14,13 +14,15 @@ export const OHRIObsGroup: React.FC<ObsGroupProps> = ({ question, onChange, dele
   const { encounterContext } = React.useContext(OHRIFormContext);
 
   useEffect(() => {
-    Promise.all(
-      question.questions.map(field => {
-        return getFieldControl(field)?.then(result => ({ field, control: result.default }));
-      }),
-    ).then(results => {
-      setGroupMembersControlMap(results);
-    });
+    if (question.questions) {
+      Promise.all(
+        question.questions.map(field => {
+          return getFieldControl(field)?.then(result => ({ field, control: result.default }));
+        }),
+      ).then(results => {
+        setGroupMembersControlMap(results);
+      });
+    }
   }, [question.questions]);
   const groupContent = groupMembersControlMap
     .filter(groupMemberMapItem => !!groupMemberMapItem && !groupMemberMapItem.field.isHidden)

--- a/src/components/repeat/ohri-repeat.component.tsx
+++ b/src/components/repeat/ohri-repeat.component.tsx
@@ -98,7 +98,7 @@ export const OHRIRepeat: React.FC<OHRIFormFieldProps> = ({ question, onChange })
       values[`${q.id}`] = initialValue ? initialValue : q.questionOptions.rendering == 'checkbox' ? [] : '';
 
       //Evaluate hide expressions
-      if (q['hide'].hideWhenExpression) {
+      if (q['hide'] && q['hide'].hideWhenExpression) {
         let updatedExpression = updateFieldIdInExpression(q['hide'].hideWhenExpression, idSuffix, questionIds);
         q['hide'].hideWhenExpression = updatedExpression;
         q.isHidden = evaluateExpression(updatedExpression, { value: q, type: 'field' }, fields, values, {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Add null checks for `ohri-obs-group` and `ohri-repeat` components to avoid them failing if an undefined question is wired in the form.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
