### PR TITLE
(chore) Cacheable ESLint output

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "homepage": "https://github.com/openmrs/openmrs-form-engine-lib#readme",
   "scripts": {
-    "lint": "eslint src --ext tsx --fix",
+    "lint": "TIMING=1 eslint src --ext tsx --fix",
     "verify": "turbo run lint && turbo run typescript && yarn run test",
     "prettier": "prettier --config prettier.config.js --write \"src/**/*.{ts,tsx}\"",
     "typescript": "tsc",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Adds a `TIMING=1` variable to the lint step, essentially ensuring we have some output from linting that can be [cached](https://turbo.build/repo/docs/core-concepts/caching#configuring-cache-outputs).
