### PR TITLE
O3-2016 Fix overlapping radio and checkbox text

### DIFF
--- a/src/components/inputs/radio/ohri-radio.component.tsx
+++ b/src/components/inputs/radio/ohri-radio.component.tsx
@@ -70,7 +70,7 @@ const OHRIRadio: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }
       <div className={styles.row}>
         <div>
           <FormGroup
-            style={{ paddingBottom: '1rem', width: '22.313rem' }}
+            style={{ paddingBottom: '1rem' }}
             legendText={question.label}
             className={isFieldRequiredError ? styles.errorLegend : undefined}
             disabled={question.disabled}

--- a/src/ohri-form.scss
+++ b/src/ohri-form.scss
@@ -19,6 +19,7 @@
 
 .ohriFormContainer :global(.cds--label) {
   font-size: 0.875rem;
+  width: 18rem;
 }
 
 .formContent {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Fix overlapping radio and checkbox text (Updated the input width to match the container width)

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="606" alt="O3-2016" src="https://user-images.githubusercontent.com/19533785/230320761-332e0840-3576-4597-90a0-a57f3364d116.PNG">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
