### PR TITLE
O3-2050 prevent number input change on mouse/touchpad scroll

### DIFF
--- a/src/components/inputs/number/ohri-number.component.tsx
+++ b/src/components/inputs/number/ohri-number.component.tsx
@@ -97,6 +97,7 @@ const OHRINumber: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
             allowEmpty={true}
             size="lg"
             hideSteppers={true}
+            onWheel={e => e.target.blur()}
             disabled={question.disabled}
             className={isFieldRequiredError ? styles.errorLabel : ''}
             warn={warnings.length > 0}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
Number input values have been incrementing and decrementing when in focus and a mouse is scrolled. 

## Screenshots

https://user-images.githubusercontent.com/15266028/232490071-24b5dcea-bec9-435b-a4e1-95a8a2e5ed3e.mov



## Related Issue

[<!-- https://issues.openmrs.org/browse/O3- -->](https://issues.openmrs.org/browse/O3-2050)

## Other
<!-- Anything not covered above -->
