### PR TITLE
O3-2057 Add support to display error messages on Number input control

### DIFF
--- a/src/components/encounter/ohri-encounter-form.tsx
+++ b/src/components/encounter/ohri-encounter-form.tsx
@@ -425,6 +425,22 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
       errors.push(...errorsAndWarinings.filter(error => error.resultType == 'error'));
       warnings.push(...errorsAndWarinings.filter(error => error.resultType == 'warning'));
     }
+    if (field.questionOptions.rendering == 'number') {
+      let min = field.questionOptions.min;
+      let max = field.questionOptions.max;
+      if (min && Number(value) < Number(min)) {
+        errors.push({
+          resultType: 'error',
+          message: `Field value can't be less than ${min}`,
+        });
+        if (max && Number(value) > Number(max)) {
+          errors.push({
+            resultType: 'error',
+            message: `Field value can't be greater than ${max}`,
+          });
+        }
+      }
+    }
     setErrors?.(errors);
     setWarnings?.(warnings);
     if (errors.length) {

--- a/src/components/encounter/ohri-encounter-form.tsx
+++ b/src/components/encounter/ohri-encounter-form.tsx
@@ -28,7 +28,6 @@ import { scrollIntoView } from '../../utils/ohri-sidebar';
 import { useEncounter } from '../../hooks/useEncounter';
 import { useInitialValues } from '../../hooks/useInitialValues';
 import { useEncounterRole } from '../../hooks/useEncounterRole';
-import { OHRIDefaultFieldValueValidator } from '../../validators/default-value-validator';
 
 interface OHRIEncounterFormProps {
   formJson: OHRIFormSchema;
@@ -425,13 +424,6 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
         getValidator(validatorConfig.type)?.validate(field, value, { ...basevalidatorConfig, ...validatorConfig }) ||
         [];
       errors.push(...errorsAndWarinings.filter(error => error.resultType == 'error'));
-
-      const defaultValueValidation = OHRIDefaultFieldValueValidator.validate(field, value);
-      if (defaultValueValidation.length) {
-        defaultValueValidation.map(error => {
-          errors.push(error);
-        });
-      }
       warnings.push(...errorsAndWarinings.filter(error => error.resultType == 'warning'));
     }
     setErrors?.(errors);

--- a/src/components/encounter/ohri-encounter-form.tsx
+++ b/src/components/encounter/ohri-encounter-form.tsx
@@ -28,6 +28,7 @@ import { scrollIntoView } from '../../utils/ohri-sidebar';
 import { useEncounter } from '../../hooks/useEncounter';
 import { useInitialValues } from '../../hooks/useInitialValues';
 import { useEncounterRole } from '../../hooks/useEncounterRole';
+import { OHRIDefaultFieldValueValidator } from '../../validators/default-value-validator';
 
 interface OHRIEncounterFormProps {
   formJson: OHRIFormSchema;
@@ -394,6 +395,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
         obs: obsForSubmission,
       };
     }
+
     if (encounterForSubmission.obs?.length || encounterForSubmission.orders?.length) {
       const ac = new AbortController();
       return saveEncounter(ac, encounterForSubmission, encounter?.uuid);
@@ -423,23 +425,14 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
         getValidator(validatorConfig.type)?.validate(field, value, { ...basevalidatorConfig, ...validatorConfig }) ||
         [];
       errors.push(...errorsAndWarinings.filter(error => error.resultType == 'error'));
-      warnings.push(...errorsAndWarinings.filter(error => error.resultType == 'warning'));
-    }
-    if (field.questionOptions.rendering == 'number') {
-      let min = field.questionOptions.min;
-      let max = field.questionOptions.max;
-      if (min && Number(value) < Number(min)) {
-        errors.push({
-          resultType: 'error',
-          message: `Field value can't be less than ${min}`,
+
+      const defaultValueValidation = OHRIDefaultFieldValueValidator.validate(field, value);
+      if (defaultValueValidation.length) {
+        defaultValueValidation.map(error => {
+          errors.push(error);
         });
-        if (max && Number(value) > Number(max)) {
-          errors.push({
-            resultType: 'error',
-            message: `Field value can't be greater than ${max}`,
-          });
-        }
       }
+      warnings.push(...errorsAndWarinings.filter(error => error.resultType == 'warning'));
     }
     setErrors?.(errors);
     setWarnings?.(warnings);

--- a/src/validators/default-value-validator.ts
+++ b/src/validators/default-value-validator.ts
@@ -23,25 +23,6 @@ export const OHRIDefaultFieldValueValidator: FieldValidator = {
         return [
           { resultType: 'error', errCode: 'invalid.defaultValue', message: `Invalid numerical  value: '${value}'` },
         ];
-      } else {
-        let min = field.questionOptions.min;
-        let max = field.questionOptions.max;
-        if (min && Number(value) < Number(min)) {
-          return [
-            {
-              resultType: 'error',
-              message: `Field value can't be less than ${min}`,
-            },
-          ];
-        }
-        if (max && Number(value) > Number(max)) {
-          return [
-            {
-              resultType: 'error',
-              message: `Field value can't be greater than ${max}`,
-            },
-          ];
-        }
       }
     }
     return [];

--- a/src/validators/default-value-validator.ts
+++ b/src/validators/default-value-validator.ts
@@ -23,6 +23,25 @@ export const OHRIDefaultFieldValueValidator: FieldValidator = {
         return [
           { resultType: 'error', errCode: 'invalid.defaultValue', message: `Invalid numerical  value: '${value}'` },
         ];
+      } else {
+        let min = field.questionOptions.min;
+        let max = field.questionOptions.max;
+        if (min && Number(value) < Number(min)) {
+          return [
+            {
+              resultType: 'error',
+              message: `Field value can't be less than ${min}`,
+            },
+          ];
+        }
+        if (max && Number(value) > Number(max)) {
+          return [
+            {
+              resultType: 'error',
+              message: `Field value can't be greater than ${max}`,
+            },
+          ];
+        }
       }
     }
     return [];

--- a/src/validators/ohri-form-validator.ts
+++ b/src/validators/ohri-form-validator.ts
@@ -15,24 +15,25 @@ export const OHRIFieldValidator: FieldValidator = {
       }
     }
     if (field.questionOptions.rendering == 'number') {
-      let min = field.questionOptions.min;
-      let max = field.questionOptions.max;
-
-      if (min && Number(value) < Number(min)) {
+      const min = field.questionOptions.min;
+      const max = field.questionOptions.max;
+      if (min && value < Number(min)) {
         return [
           {
             resultType: 'error',
             errCode: fieldOutOfBoundErrCode,
+            // TODO: handle i18n
             message: `Field value can't be less than ${min}`,
           },
         ];
       }
 
-      if (max && Number(value) > Number(max)) {
+      if (max && value > Number(max)) {
         return [
           {
             resultType: 'error',
             errCode: fieldOutOfBoundErrCode,
+            // TODO: handle i18n
             message: `Field value can't be greater than ${max}`,
           },
         ];

--- a/src/validators/ohri-form-validator.ts
+++ b/src/validators/ohri-form-validator.ts
@@ -2,6 +2,7 @@ import { FieldValidator, OHRIFormField } from '../api/types';
 import { isTrue } from '../utils/boolean-utils';
 
 export const fieldRequiredErrCode = 'field.required';
+export const fieldOutOfBoundErrCode = 'field.outOfBound';
 
 export const OHRIFieldValidator: FieldValidator = {
   validate: (field: OHRIFormField, value: any) => {
@@ -11,6 +12,30 @@ export const OHRIFieldValidator: FieldValidator = {
     if (isTrue(field.required) || isTrue(field.unspecified)) {
       if (isEmpty(value)) {
         return [{ resultType: 'error', errCode: fieldRequiredErrCode, message: 'Field is mandatory' }];
+      }
+    }
+    if (field.questionOptions.rendering == 'number') {
+      let min = field.questionOptions.min;
+      let max = field.questionOptions.max;
+
+      if (min && Number(value) < Number(min)) {
+        return [
+          {
+            resultType: 'error',
+            errCode: fieldOutOfBoundErrCode,
+            message: `Field value can't be less than ${min}`,
+          },
+        ];
+      }
+
+      if (max && Number(value) > Number(max)) {
+        return [
+          {
+            resultType: 'error',
+            errCode: fieldOutOfBoundErrCode,
+            message: `Field value can't be greater than ${max}`,
+          },
+        ];
       }
     }
     return [];


### PR DESCRIPTION
This PR fixes the issue where there's an error on the number field and field is highlighted in red but no error message is displayed.

<img width="867" alt="Screenshot 2023-04-17 at 16 43 50" src="https://user-images.githubusercontent.com/12844964/232502691-b9baf491-28be-492d-b0c7-ab8fbcc269ec.png">
