### PR TITLE
(fix) Yet more miscellaneous fixes

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { encounterRepresentation } from '../constants';
 import { OpenmrsForm } from './types';
-import { isLikeUUID } from '../utils/boolean-utils';
+import { isUuid } from '../utils/boolean-utils';
 
 export function saveEncounter(abortController: AbortController, payload, encounterUuid?: string) {
   const url = !!encounterUuid ? `/ws/rest/v1/encounter/${encounterUuid}?v=full` : `/ws/rest/v1/encounter?v=full`;
@@ -58,7 +58,7 @@ export async function getOpenMRSForm(nameOrUUID: string): Promise<OpenmrsForm> {
   if (!nameOrUUID) {
     return null;
   }
-  const { url, isUUID } = isLikeUUID(nameOrUUID)
+  const { url, isUUID } = isUuid(nameOrUUID)
     ? { url: `/ws/rest/v1/form/${nameOrUUID}?v=full`, isUUID: true }
     : { url: `/ws/rest/v1/form?q=${nameOrUUID}&v=full`, isUUID: false };
 

--- a/src/components/encounter/ohri-encounter-form.tsx
+++ b/src/components/encounter/ohri-encounter-form.tsx
@@ -381,7 +381,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
         ];
         encounterForSubmission['form'] = {
           uuid: encounterContext?.form?.uuid,
-        }
+        };
       }
       encounterForSubmission['obs'] = obsForSubmission;
     } else {
@@ -399,7 +399,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
         obs: obsForSubmission,
         form: {
           uuid: encounterContext?.form?.uuid,
-        }
+        },
       };
     }
     if (encounterForSubmission.obs?.length || encounterForSubmission.orders?.length) {

--- a/src/components/encounter/ohri-encounter-form.tsx
+++ b/src/components/encounter/ohri-encounter-form.tsx
@@ -1,5 +1,5 @@
-import { useLayoutType } from '@openmrs/esm-framework';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { SessionLocation, useLayoutType } from '@openmrs/esm-framework';
 import { ConceptFalse, ConceptTrue } from '../../constants';
 import { OHRIFormContext } from '../../ohri-form-context';
 import { getHandler, getValidator } from '../../registry/registry';
@@ -34,7 +34,7 @@ interface OHRIEncounterFormProps {
   patient: any;
   encounterDate: Date;
   provider: string;
-  location: { uuid: string; name: string };
+  location: SessionLocation;
   values: Record<string, any>;
   isCollapsed: boolean;
   sessionMode: SessionMode;
@@ -209,7 +209,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
 
   useEffect(() => {
     if (sessionMode == 'enter' && !formJson.formOptions?.usePreviousValueDisabled) {
-      getPreviousEncounter(patient.id, formJson.encounterType).then(data => {
+      getPreviousEncounter(patient?.id, formJson?.encounterType).then(data => {
         setPreviousEncounter(data);
         setIsLoadingPreviousEncounter(false);
       });
@@ -335,7 +335,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
       .forEach(field => {
         if (field.type == 'obsGroup') {
           const obsGroup = {
-            person: patient.id,
+            person: patient?.id,
             obsDatetime: encounterDate,
             concept: field.questionOptions.concept,
             location: encounterLocation,

--- a/src/components/inputs/date/ohri-date.component.tsx
+++ b/src/components/inputs/date/ohri-date.component.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import moment from 'moment';
 import { OHRIFormFieldProps } from '../../../api/types';
 import { DatePicker, DatePickerInput, TimePicker } from '@carbon/react';
 import { useField } from 'formik';
 import { OHRIFormContext } from '../../../ohri-form-context';
-import styles from '../_input.scss';
 import { fieldRequiredErrCode, isEmpty } from '../../../validators/ohri-form-validator';
 import { isTrue } from '../../../utils/boolean-utils';
 import { getConceptNameAndUUID, isInlineView } from '../../../utils/ohri-form-helper';
 import { OHRIFieldValueView } from '../../value/view/ohri-field-value-view.component';
 import { PreviousValueReview } from '../../previous-value-review/previous-value-review.component';
-import moment from 'moment';
+import styles from '../_input.scss';
 
 const dateFormatter = new Intl.DateTimeFormat(window.navigator.language);
 
@@ -58,13 +58,13 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
       currentDateTime.setHours(splitTime[0] ?? '00', splitTime[1] ?? '00');
       setFieldValue(question.id, currentDateTime);
       onChange(question.id, currentDateTime, setErrors, setWarnings);
-      question.value = handler.handleFieldSubmission(question, currentDateTime, encounterContext);
+      question.value = handler?.handleFieldSubmission(question, currentDateTime, encounterContext);
       setTime(time);
     }
   };
-  const { placeHolder, carbonDateformat } = useMemo(() => {
+  const { placeholder, carbonDateformat } = useMemo(() => {
     const formatObj = dateFormatter.formatToParts(new Date());
-    const placeHolder = formatObj
+    const placeholder = formatObj
       .map(obj => {
         switch (obj.type) {
           case 'day':
@@ -92,7 +92,7 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
         }
       })
       .join('');
-    return { placeHolder: placeHolder, carbonDateformat: carbonDateformat };
+    return { placeholder: placeholder, carbonDateformat: carbonDateformat };
   }, []);
 
   useEffect(() => {
@@ -153,7 +153,7 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
               dateFormat={carbonDateformat}>
               <DatePickerInput
                 id={question.id}
-                placeholder={placeHolder}
+                placeholder={placeholder}
                 labelText={question.label}
                 value={
                   field.value instanceof Date ? field.value.toLocaleDateString(window.navigator.language) : field.value
@@ -174,10 +174,11 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
           </div>
           {question?.questionOptions.rendering === 'datetime' ? (
             <TimePicker
+              className={styles.timePicker}
               id={question.id}
-              labelText="Order time"
+              labelText="Time:"
               placeholder="HH:MM"
-              pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?"
+              pattern="(1[012]|[1-9]):[0-5][0-9])$"
               type="time"
               disabled={!field.value ? true : false}
               value={
@@ -187,7 +188,8 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
                   ? field.value.toLocaleDateString(window.navigator.language)
                   : field.value
               }
-              onChange={onTimeChange}></TimePicker>
+              onChange={onTimeChange}
+            />
           ) : (
             ''
           )}

--- a/src/components/sidebar/ohri-form-sidebar.component.tsx
+++ b/src/components/sidebar/ohri-form-sidebar.component.tsx
@@ -7,7 +7,7 @@ import { scrollIntoView } from '../../utils/ohri-sidebar';
 function OHRIFormSidebar({
   isFormSubmitting,
   pagesWithErrors,
-  scrollAblePages,
+  scrollablePages,
   selectedPage,
   mode,
   onCancel,
@@ -20,7 +20,7 @@ function OHRIFormSidebar({
   const [activeLink, setActiveLink] = useState(selectedPage);
 
   useEffect(() => {
-    if (defaultPage && [...scrollAblePages].find(({ label, isHidden }) => label === defaultPage && !isHidden)) {
+    if (defaultPage && [...scrollablePages].find(({ label, isHidden }) => label === defaultPage && !isHidden)) {
       scrollIntoView(joinWord(defaultPage));
     }
   }, [defaultPage]);
@@ -65,7 +65,7 @@ function OHRIFormSidebar({
   );
   return (
     <div className={styles.sidebar}>
-      {[...scrollAblePages].map((page, index) => {
+      {[...scrollablePages].map((page, index) => {
         return (
           !page.isHidden && (
             <div

--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -96,7 +96,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
   const session = useSession();
   const [initialValues, setInitialValues] = useState({});
   const encDate = new Date();
-  const [scrollAblePages, setScrollablePages] = useState(new Set<OHRIFormPageProps>());
+  const [scrollablePages, setScrollablePages] = useState(new Set<OHRIFormPageProps>());
   const [selectedPage, setSelectedPage] = useState('');
   const [collapsed, setCollapsed] = useState(true);
   const { t } = useTranslation();
@@ -116,8 +116,8 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
   }, [mode, encounterUUID, encounterUuid]);
 
   const showSideBar = useMemo(() => {
-    return workspaceLayout != 'minimized' && scrollAblePages.size > 0;
-  }, [workspaceLayout, scrollAblePages.size]);
+    return workspaceLayout != 'minimized' && scrollablePages.size > 0;
+  }, [workspaceLayout, scrollablePages.size]);
 
   useEffect(() => {
     const extDetails = {
@@ -257,7 +257,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                   <OHRIFormSidebar
                     isFormSubmitting={isSubmitting}
                     pagesWithErrors={pagesWithErrors}
-                    scrollAblePages={scrollAblePages}
+                    scrollablePages={scrollablePages}
                     selectedPage={selectedPage}
                     mode={mode}
                     onCancel={onCancel}
@@ -288,7 +288,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                       values={props.values}
                       isCollapsed={collapsed}
                       sessionMode={sessionMode}
-                      scrollablePages={scrollAblePages}
+                      scrollablePages={scrollablePages}
                       setAllInitialValues={setInitialValues}
                       allInitialValues={initialValues}
                       setScrollablePages={setScrollablePages}

--- a/src/submission-handlers/base-handlers.ts
+++ b/src/submission-handlers/base-handlers.ts
@@ -184,7 +184,7 @@ export const EncounterLocationSubmissionHandler: SubmissionHandler = {
 
 const constructObs = (value: any, context: EncounterContext, field: OHRIFormField) => {
   return {
-    person: context.patient.id,
+    person: context.patient?.id,
     obsDatetime: context.date,
     concept: field.questionOptions.concept,
     location: context.location,

--- a/src/utils/boolean-utils.ts
+++ b/src/utils/boolean-utils.ts
@@ -17,10 +17,9 @@ export function isTrue(value: string | boolean): boolean {
 }
 
 /**
- * Checks whether a string is a "like" UUID.
- * A "like" UUID is a string that has the format of a UUID, but is not necessarily a valid UUID.
+ * Checks whether a string is a UUID
  */
-export function isLikeUUID(s: string): boolean {
-  const pattern = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-  return pattern.test(s);
+export function isUuid(value: string): boolean {
+  const uuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+  return uuidRegex.test(value);
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Adds yet more miscellaneous fixes, including:

- Renaming the default label for the `Timepicker` component that gets rendered when the `datetime` rendering type gets used. 
- Ensuring nested properties of `handler` objects can be accessed safely. Ideally, the existence of these properties ought to be determined ahead of time, but this fix carries us over for the time being. 
- Minimal refactors, including renaming a function that determines whether its parameter is a UUID.