### PR TITLE
fixed different timestamps on obs

### DIFF
--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -99,7 +99,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
   );
 
   const { t } = useTranslation();
-  const encDate = new Date();
+  const encDate = useMemo(() => new Date(), []);
   const handlers = new Map<string, FormSubmissionHandler>();
   const ref = useRef(null);
   const workspaceLayout = useWorkspaceLayout(ref);


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The form engine attaches a unique timestamp for every observation. It should just have one time-stamp since they are recorded at the same time.
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
