### PR TITLE
Introduce maxLength and minLength params for text fields

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -139,8 +139,16 @@ export interface OHRIFormQuestionOptions {
   extensionSlotName?: string;
   rendering: RenderType;
   concept?: string;
+  /**
+   * max and min are used to validate number field values
+   */
   max?: string;
   min?: string;
+  /**
+   * maxLength and maxLength are used to validate text field length
+   */
+  maxLength?: string;
+  minLength?: string;
   showDate?: string;
   conceptMappings?: Array<Record<any, any>>;
   answers?: Array<Record<any, any>>;
@@ -196,8 +204,8 @@ export interface OpenmrsEncounter {
   visit?: OpenmrsResource | string;
   encounterProviders?: Array<Record<string, any>>;
   form?: {
-    uuid: string,
-  }
+    uuid: string;
+  };
 }
 
 export interface OpenmrsObs extends OpenmrsResource {

--- a/src/validators/ohri-form-validator.test.ts
+++ b/src/validators/ohri-form-validator.test.ts
@@ -42,7 +42,7 @@ describe('OHRIFieldValidator - validate', () => {
     questionOptions: {
       rendering: 'text',
       concept: 'a-system-defined-concept-uuid',
-      min: '5',
+      minLength: '5',
     },
     id: 'sampleTextQuestion',
   };
@@ -53,7 +53,7 @@ describe('OHRIFieldValidator - validate', () => {
     questionOptions: {
       rendering: 'text',
       concept: 'a-system-defined-concept-uuid',
-      max: '10',
+      maxLength: '10',
     },
     id: 'sampleTextQuestion',
   };
@@ -64,7 +64,7 @@ describe('OHRIFieldValidator - validate', () => {
     expect(validationErrors).toEqual([
       {
         errCode: 'field.outOfBound',
-        message: `Field length error, field length can't be greater than ${textInputField.questionOptions.max}`,
+        message: `Field length error, field length can't be greater than ${textInputField.questionOptions.maxLength}`,
         resultType: 'error',
       },
     ]);
@@ -76,7 +76,7 @@ describe('OHRIFieldValidator - validate', () => {
     expect(validationErrors).toEqual([
       {
         errCode: 'field.outOfBound',
-        message: `Field length error, field length can't be less than ${textInputField.questionOptions.min}`,
+        message: `Field length error, field length can't be less than ${textInputField.questionOptions.minLength}`,
         resultType: 'error',
       },
     ]);
@@ -130,6 +130,7 @@ describe('OHRIFieldValidator - validate', () => {
     expect(validationErrors).toEqual([]);
   });
 
+  // Number Input Validator Tests
   it('should fail for number lesser than the defined min allowed', () => {
     const validationErrors = OHRIFieldValidator.validate(numberInputField, 3);
 

--- a/src/validators/ohri-form-validator.test.ts
+++ b/src/validators/ohri-form-validator.test.ts
@@ -20,8 +20,8 @@ describe('OHRIFieldValidator - validate', () => {
     questionOptions: {
       rendering: 'text',
       concept: 'a-system-defined-concept-uuid',
-      min: '5',
-      max: '10',
+      minLength: '5',
+      maxLength: '10',
     },
     id: 'sampleTextQuestion',
   };
@@ -97,7 +97,7 @@ describe('OHRIFieldValidator - validate', () => {
     expect(validationErrors).toEqual([
       {
         errCode: 'field.outOfBound',
-        message: `Field length error, field length should be between ${textInputField.questionOptions.min} and ${textInputField.questionOptions.max}.`,
+        message: `Field length error, field length should be between ${textInputField.questionOptions.minLength} and ${textInputField.questionOptions.maxLength}.`,
         resultType: 'error',
       },
     ]);
@@ -109,7 +109,7 @@ describe('OHRIFieldValidator - validate', () => {
     expect(validationErrors).toEqual([
       {
         errCode: 'field.outOfBound',
-        message: `Field length error, field length should be between ${textInputField.questionOptions.min} and ${textInputField.questionOptions.max}.`,
+        message: `Field length error, field length should be between ${textInputField.questionOptions.minLength} and ${textInputField.questionOptions.maxLength}.`,
         resultType: 'error',
       },
     ]);

--- a/src/validators/ohri-form-validator.ts
+++ b/src/validators/ohri-form-validator.ts
@@ -19,7 +19,11 @@ export const OHRIFieldValidator: FieldValidator = {
       return numberInputRangeValidator(Number(field.questionOptions.min), Number(field.questionOptions.max), value);
     }
     if (field.questionOptions.rendering == 'text') {
-      return textInputLengthValidator(Number(field.questionOptions.min), Number(field.questionOptions.max), value);
+      return textInputLengthValidator(
+        Number(field.questionOptions.minLength),
+        Number(field.questionOptions.maxLength),
+        value,
+      );
     }
     return [];
   },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
Both text and number fields have been using `min` and `max` params which caused a little bit of confusion putting into consideration the context. This PR introduces `minLength` and `maxLength` specifically for `field.length` validation.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
