### PR TITLE
Add provision for Encounter Date Time

### DIFF
--- a/src/components/encounter/ohri-encounter-form.tsx
+++ b/src/components/encounter/ohri-encounter-form.tsx
@@ -32,7 +32,7 @@ import { useEncounterRole } from '../../hooks/useEncounterRole';
 interface OHRIEncounterFormProps {
   formJson: OHRIFormSchema;
   patient: any;
-  encounterDate: Date;
+  formSessionDate: Date;
   provider: string;
   location: SessionLocation;
   visit?: Visit;
@@ -55,7 +55,7 @@ interface OHRIEncounterFormProps {
 export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
   formJson,
   patient,
-  encounterDate,
+  formSessionDate,
   provider,
   location,
   visit,
@@ -76,6 +76,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
 }) => {
   const [fields, setFields] = useState<Array<OHRIFormField>>([]);
   const [encounterLocation, setEncounterLocation] = useState(null);
+  const [encounterDate, setEncounterDate] = useState(formSessionDate);
   const { encounter, isLoading: isLoadingEncounter } = useEncounter(formJson);
   const [previousEncounter, setPreviousEncounter] = useState<OpenmrsEncounter>(null);
   const [isLoadingPreviousEncounter, setIsLoadingPreviousEncounter] = useState(true);
@@ -92,11 +93,12 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
       previousEncounter,
       location: location,
       sessionMode: sessionMode || (form?.encounter ? 'edit' : 'enter'),
-      date: encounterDate,
+      encounterDate: formSessionDate,
       form: form,
       visit: visit,
+      setEncounterDate,
     }),
-    [encounter, encounterDate, form?.encounter, location, patient, previousEncounter, sessionMode],
+    [encounter, form?.encounter, location, patient, previousEncounter, sessionMode],
   );
   const { encounterRole } = useEncounterRole();
 
@@ -382,12 +384,12 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
             encounterRole: encounterRole?.uuid,
           },
         ];
-        encounterForSubmission['form'] = {
+        (encounterForSubmission['form'] = {
           uuid: encounterContext?.form?.uuid,
-        },
-        encounterForSubmission['visit'] = {
-          uuid: visit?.uuid
-        }
+        }),
+          (encounterForSubmission['visit'] = {
+            uuid: visit?.uuid,
+          });
       }
       encounterForSubmission['obs'] = obsForSubmission;
     } else {
@@ -566,7 +568,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
               key={index}
               formJson={page.subform?.form}
               patient={patient}
-              encounterDate={encounterDate}
+              formSessionDate={encounterDate}
               provider={provider}
               location={location}
               visit={visit}

--- a/src/components/inputs/content-switcher/ohri-content-switcher.component.test.tsx
+++ b/src/components/inputs/content-switcher/ohri-content-switcher.component.test.tsx
@@ -43,7 +43,8 @@ const encounterContext: EncounterContext = {
     obs: [],
   },
   sessionMode: 'enter',
-  date: new Date(2020, 11, 29),
+  encounterDate: new Date(2020, 11, 29),
+  setEncounterDate: value => {},
 };
 
 const renderForm = intialValues => {
@@ -112,7 +113,7 @@ describe('content-switcher input field', () => {
     question.value = {
       uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
       person: '833db896-c1f0-11eb-8529-0242ac130003',
-      obsDatetime: encounterContext.date,
+      obsDatetime: encounterContext.encounterDate,
       concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
       location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
       order: null,

--- a/src/components/inputs/select/ohri-dropdown.component.test.tsx
+++ b/src/components/inputs/select/ohri-dropdown.component.test.tsx
@@ -43,7 +43,8 @@ const encounterContext: EncounterContext = {
     obs: [],
   },
   sessionMode: 'enter',
-  date: new Date(2020, 11, 29),
+  encounterDate: new Date(2020, 11, 29),
+  setEncounterDate: value => {},
 };
 
 const renderForm = intialValues => {
@@ -114,7 +115,7 @@ describe('dropdown input field', () => {
     question.value = {
       uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
       person: '833db896-c1f0-11eb-8529-0242ac130003',
-      obsDatetime: encounterContext.date,
+      obsDatetime: encounterContext.encounterDate,
       concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
       location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
       order: null,

--- a/src/components/inputs/unspecified/ohri-unspecified.component.test.tsx
+++ b/src/components/inputs/unspecified/ohri-unspecified.component.test.tsx
@@ -26,7 +26,8 @@ const encounterContext: EncounterContext = {
     obs: [],
   },
   sessionMode: 'enter',
-  date: new Date(2020, 11, 29),
+  encounterDate: new Date(2020, 11, 29),
+  setEncounterDate: value => {},
 };
 
 const renderForm = intialValues => {

--- a/src/ohri-form-context.tsx
+++ b/src/ohri-form-context.tsx
@@ -22,7 +22,8 @@ export interface EncounterContext {
   previousEncounter?: OpenmrsEncounter;
   location: any;
   sessionMode: SessionMode;
-  date: Date;
+  encounterDate: Date;
+  setEncounterDate(value: Date): void;
 }
 
 export const OHRIFormContext = React.createContext<OHRIFormContextProps | undefined>(undefined);

--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -99,7 +99,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
   );
 
   const { t } = useTranslation();
-  const encDate = useMemo(() => new Date(), []);
+  const formSessionDate = useMemo(() => new Date(), []);
   const handlers = new Map<string, FormSubmissionHandler>();
   const ref = useRef(null);
   const workspaceLayout = useWorkspaceLayout(ref);
@@ -281,7 +281,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                     <OHRIEncounterForm
                       formJson={refinedFormJson}
                       patient={patient}
-                      encounterDate={encDate}
+                      formSessionDate={formSessionDate}
                       provider={currentProvider}
                       location={location}
                       visit={visit}

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -20,6 +20,7 @@ import { OHRIJSExpressionValidator } from '../validators/ohri-js-expression-vali
 import { getGlobalStore } from '@openmrs/esm-framework';
 import { OHRIFormsStore } from '../constants';
 import OHRIExtensionParcel from '../components/extension/ohri-extension-parcel.component';
+import { EncounterDatetimeHandler } from '../submission-handlers/encounterDatetimeHandler';
 
 export interface RegistryItem {
   id: string;
@@ -147,6 +148,11 @@ const baseHandlers: Array<RegistryItem> = [
     id: 'EncounterLocationSubmissionHandler',
     component: EncounterLocationSubmissionHandler,
     type: 'encounterLocation',
+  },
+  {
+    id: 'EncounterDatetimeHandler',
+    component: EncounterDatetimeHandler,
+    type: 'encounterDatetime',
   },
 ];
 

--- a/src/submission-handlers/base-handlers.test.ts
+++ b/src/submission-handlers/base-handlers.test.ts
@@ -15,7 +15,8 @@ const encounterContext: EncounterContext = {
     obs: [],
   },
   sessionMode: 'enter',
-  date: new Date(2020, 11, 29),
+  encounterDate: new Date(2020, 11, 29),
+  setEncounterDate: value => {},
 };
 
 describe('ObsSubmissionHandler - handleFieldSubmission', () => {
@@ -36,7 +37,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     // verify
     expect(obs).toEqual({
       person: '833db896-c1f0-11eb-8529-0242ac130003',
-      obsDatetime: encounterContext.date,
+      obsDatetime: encounterContext.encounterDate,
       concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
       location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
       order: null,
@@ -64,7 +65,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     // verify
     expect(obs).toEqual({
       person: '833db896-c1f0-11eb-8529-0242ac130003',
-      obsDatetime: encounterContext.date,
+      obsDatetime: encounterContext.encounterDate,
       concept: '2c43u05b-b6d8-4eju-8f37-0b14f5347560',
       location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
       order: null,
@@ -104,7 +105,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     expect(obs).toEqual([
       {
         person: '833db896-c1f0-11eb-8529-0242ac130003',
-        obsDatetime: encounterContext.date,
+        obsDatetime: encounterContext.encounterDate,
         concept: '3hbkj9-b6d8-4eju-8f37-0b14f5347jv9',
         location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
         order: null,
@@ -128,7 +129,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     expect(obs).toEqual([
       {
         person: '833db896-c1f0-11eb-8529-0242ac130003',
-        obsDatetime: encounterContext.date,
+        obsDatetime: encounterContext.encounterDate,
         concept: '3hbkj9-b6d8-4eju-8f37-0b14f5347jv9',
         location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
         order: null,
@@ -140,7 +141,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
       },
       {
         person: '833db896-c1f0-11eb-8529-0242ac130003',
-        obsDatetime: encounterContext.date,
+        obsDatetime: encounterContext.encounterDate,
         concept: '3hbkj9-b6d8-4eju-8f37-0b14f5347jv9',
         location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
         order: null,
@@ -170,7 +171,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     // verify
     expect(obs).toEqual({
       person: '833db896-c1f0-11eb-8529-0242ac130003',
-      obsDatetime: encounterContext.date,
+      obsDatetime: encounterContext.encounterDate,
       concept: 'j8b6705b-b6d8-4eju-8f37-0b14f5347569',
       location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
       order: null,
@@ -202,7 +203,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     // verify
     expect(obs).toEqual({
       person: '833db896-c1f0-11eb-8529-0242ac130003',
-      obsDatetime: encounterContext.date,
+      obsDatetime: encounterContext.encounterDate,
       concept: '89jbi9jk-b6d8-4eju-8f37-0b14f53mhj098b',
       location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
       order: null,
@@ -228,7 +229,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
       value: {
         uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
         person: '833db896-c1f0-11eb-8529-0242ac130003',
-        obsDatetime: encounterContext.date,
+        obsDatetime: encounterContext.encounterDate,
         concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
         location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
         order: null,
@@ -246,7 +247,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     expect(obs).toEqual({
       uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
       person: '833db896-c1f0-11eb-8529-0242ac130003',
-      obsDatetime: encounterContext.date,
+      obsDatetime: encounterContext.encounterDate,
       concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
       location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
       order: null,
@@ -269,7 +270,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
       value: {
         uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
         person: '833db896-c1f0-11eb-8529-0242ac130003',
-        obsDatetime: encounterContext.date,
+        obsDatetime: encounterContext.encounterDate,
         concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
         location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
         order: null,
@@ -289,7 +290,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     expect(obs).toEqual({
       uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
       person: '833db896-c1f0-11eb-8529-0242ac130003',
-      obsDatetime: encounterContext.date,
+      obsDatetime: encounterContext.encounterDate,
       concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
       location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
       order: null,
@@ -317,7 +318,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
         {
           uuid: 'f2487de5-e55f-4689-8791-0c919179818b',
           person: '833db896-c1f0-11eb-8529-0242ac130003',
-          obsDatetime: encounterContext.date,
+          obsDatetime: encounterContext.encounterDate,
           concept: '3hbkj9-b6d8-4eju-8f37-0b14f5347jv9',
           location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
           order: null,
@@ -345,7 +346,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
       {
         uuid: 'f2487de5-e55f-4689-8791-0c919179818b',
         person: '833db896-c1f0-11eb-8529-0242ac130003',
-        obsDatetime: encounterContext.date,
+        obsDatetime: encounterContext.encounterDate,
         concept: '3hbkj9-b6d8-4eju-8f37-0b14f5347jv9',
         location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
         order: null,
@@ -359,7 +360,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
       },
       {
         person: '833db896-c1f0-11eb-8529-0242ac130003',
-        obsDatetime: encounterContext.date,
+        obsDatetime: encounterContext.encounterDate,
         concept: '3hbkj9-b6d8-4eju-8f37-0b14f5347jv9',
         location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
         order: null,
@@ -385,7 +386,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
       value: {
         uuid: 'bca7277f-a726-4d3d-9db8-40937228ead5',
         person: '833db896-c1f0-11eb-8529-0242ac130003',
-        obsDatetime: encounterContext.date,
+        obsDatetime: encounterContext.encounterDate,
         concept: '3e432ad5-7b19-4866-a68f-abf0d9f52a01',
         location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
         order: null,
@@ -402,7 +403,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     expect(obs).toEqual({
       uuid: 'bca7277f-a726-4d3d-9db8-40937228ead5',
       person: '833db896-c1f0-11eb-8529-0242ac130003',
-      obsDatetime: encounterContext.date,
+      obsDatetime: encounterContext.encounterDate,
       concept: '3e432ad5-7b19-4866-a68f-abf0d9f52a01',
       location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
       order: null,
@@ -426,7 +427,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
       value: {
         uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
         person: '833db896-c1f0-11eb-8529-0242ac130003',
-        obsDatetime: encounterContext.date,
+        obsDatetime: encounterContext.encounterDate,
         concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
         location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
         order: null,
@@ -444,7 +445,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     expect(obs).toEqual({
       uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
       person: '833db896-c1f0-11eb-8529-0242ac130003',
-      obsDatetime: encounterContext.date,
+      obsDatetime: encounterContext.encounterDate,
       concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
       location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
       order: null,
@@ -467,7 +468,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
       value: {
         uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
         person: '833db896-c1f0-11eb-8529-0242ac130003',
-        obsDatetime: encounterContext.date,
+        obsDatetime: encounterContext.encounterDate,
         concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
         location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
         order: null,
@@ -483,7 +484,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     expect(obs).toEqual({
       uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
       person: '833db896-c1f0-11eb-8529-0242ac130003',
-      obsDatetime: encounterContext.date,
+      obsDatetime: encounterContext.encounterDate,
       concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
       location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
       order: null,
@@ -508,7 +509,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
         {
           uuid: 'f2487de5-e55f-4689-8791-0c919179818b',
           person: '833db896-c1f0-11eb-8529-0242ac130003',
-          obsDatetime: encounterContext.date,
+          obsDatetime: encounterContext.encounterDate,
           concept: '3hbkj9-b6d8-4eju-8f37-0b14f5347jv9',
           location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
           order: null,
@@ -530,7 +531,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
       {
         uuid: 'f2487de5-e55f-4689-8791-0c919179818b',
         person: '833db896-c1f0-11eb-8529-0242ac130003',
-        obsDatetime: encounterContext.date,
+        obsDatetime: encounterContext.encounterDate,
         concept: '3hbkj9-b6d8-4eju-8f37-0b14f5347jv9',
         location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
         order: null,
@@ -557,7 +558,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
       value: {
         uuid: 'bca7277f-a726-4d3d-9db8-40937228ead5',
         person: '833db896-c1f0-11eb-8529-0242ac130003',
-        obsDatetime: encounterContext.date,
+        obsDatetime: encounterContext.encounterDate,
         concept: '3e432ad5-7b19-4866-a68f-abf0d9f52a01',
         location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
         order: null,
@@ -573,7 +574,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     expect(obs).toEqual({
       uuid: 'bca7277f-a726-4d3d-9db8-40937228ead5',
       person: '833db896-c1f0-11eb-8529-0242ac130003',
-      obsDatetime: encounterContext.date,
+      obsDatetime: encounterContext.encounterDate,
       concept: '3e432ad5-7b19-4866-a68f-abf0d9f52a01',
       location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
       order: null,

--- a/src/submission-handlers/base-handlers.ts
+++ b/src/submission-handlers/base-handlers.ts
@@ -185,7 +185,7 @@ export const EncounterLocationSubmissionHandler: SubmissionHandler = {
 const constructObs = (value: any, context: EncounterContext, field: OHRIFormField) => {
   return {
     person: context.patient?.id,
-    obsDatetime: context.date,
+    obsDatetime: context.encounterDate,
     concept: field.questionOptions.concept,
     location: context.location,
     order: null,

--- a/src/submission-handlers/encounterDatetimeHandler.ts
+++ b/src/submission-handlers/encounterDatetimeHandler.ts
@@ -7,8 +7,8 @@ export const EncounterDatetimeHandler: SubmissionHandler = {
     context.setEncounterDate(value);
     return value;
   },
-  getInitialValue: (encounter: OpenmrsEncounter, field: OHRIFormField, allFormFields?: OHRIFormField[]) => {;
-    return new Date(); // pick it from the visit if present
+  getInitialValue: (encounter: OpenmrsEncounter, field: OHRIFormField, allFormFields?: OHRIFormField[]) => {
+    return new Date(); // TO DO: pick it from the visit if present
   },
 
   getDisplayValue: (field: OHRIFormField, value: any) => {

--- a/src/submission-handlers/encounterDatetimeHandler.ts
+++ b/src/submission-handlers/encounterDatetimeHandler.ts
@@ -1,0 +1,20 @@
+import { SubmissionHandler } from '..';
+import { OpenmrsEncounter, OHRIFormField } from '../api/types';
+import { EncounterContext } from '../ohri-form-context';
+
+export const EncounterDatetimeHandler: SubmissionHandler = {
+  handleFieldSubmission: (field: OHRIFormField, value: any, context: EncounterContext) => {
+    context.setEncounterDate(value);
+    return value;
+  },
+  getInitialValue: (encounter: OpenmrsEncounter, field: OHRIFormField, allFormFields?: OHRIFormField[]) => {;
+    return new Date(); // pick it from the visit if present
+  },
+
+  getDisplayValue: (field: OHRIFormField, value: any) => {
+    return field.value ? field.value : null;
+  },
+  getPreviousValue: (field: OHRIFormField, value: any) => {
+    return null;
+  },
+};


### PR DESCRIPTION
This PR adds provision for using the encounter date time type in form JSON. This is mostly important for retrospective data and if an encounter date is passed, it overrides the default(current date)

The JSON implementation is as below:
` {
                  "label": "Encounter Date:",
                  "type": "encounterDatetime",
                  "questionOptions": {
                    "rendering": "date",
                    "concept": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                  },
                  "validators": [
                    {
                      "type": "date",
                      "allowFutureDates": "false"
                    }
                  ],
                  "id": "encDate"
      }`

<img width="1018" alt="Screenshot 2023-04-21 at 15 18 42" src="https://user-images.githubusercontent.com/12844964/233634705-ea21f7ea-e245-4aba-b2a6-6ef7234161c8.png">

