### PR TITLE
Simplify the ExpressionRunner's internal workings and enhance support for custom datasources

### DIFF
--- a/src/utils/expression-parser.test.ts
+++ b/src/utils/expression-parser.test.ts
@@ -1,4 +1,12 @@
-import { parseExpression } from './expression-parser';
+import { OHRIFormField } from '../api/types';
+import { ConceptFalse } from '../constants';
+import {
+  findAndRegisterReferencedFields,
+  linkReferencedFieldValues,
+  parseExpression,
+  replaceFieldRefWithValuePath,
+} from './expression-parser';
+import { testFields } from './expression-runner.test';
 
 describe('Expression parsing', () => {
   it('should split expression 1 into parts correctly', () => {
@@ -51,5 +59,161 @@ describe('Expression parsing', () => {
     const expectedOutput = ["getValue('some id')", '?', "'was truthy'", ':', "'was false'"];
 
     expect(parseExpression(input)).toEqual(expectedOutput);
+  });
+});
+
+describe('replaceFieldRefWithValuePath', () => {
+  const field1: OHRIFormField = {
+    label: 'Visit Count',
+    type: 'obs',
+    questionOptions: {
+      rendering: 'number',
+      concept: '162576AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      answers: [],
+    },
+    id: 'htsVisitCount',
+  };
+
+  const field2: OHRIFormField = {
+    label: 'Notes',
+    type: 'obs',
+    questionOptions: {
+      rendering: 'text',
+      concept: '162576AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      answers: [],
+    },
+    id: 'notes',
+  };
+
+  const field3: OHRIFormField = {
+    label: 'Was HIV tested?',
+    type: 'obs',
+    questionOptions: {
+      rendering: 'toggle',
+      concept: '162576AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      answers: [],
+    },
+    id: 'wasHivTested',
+  };
+
+  it("should replace 'htsVisitCount' with value path", () => {
+    // setup
+    const token = "isEmpty('htsVisitCount')";
+    // replay
+    const result = replaceFieldRefWithValuePath(field1, 10, token);
+    // verify
+    expect(result).toEqual('isEmpty(fieldValues.htsVisitCount)');
+  });
+
+  it('should replace "notes" with value path', () => {
+    // setup
+    const token = 'api.getValue(notes)';
+    // replay
+    const result = replaceFieldRefWithValuePath(field2, 'Some notes', token);
+    // verify
+    expect(result).toEqual('api.getValue(fieldValues.notes)');
+  });
+
+  it('should replace "wasHivTested" with the system encoded boolean value for toggle rendering types', () => {
+    const token = "isEmpty('wasHivTested')";
+    const result = replaceFieldRefWithValuePath(field3, false, token);
+    expect(result).toEqual(`isEmpty('${ConceptFalse}')`);
+  });
+});
+
+describe('linkReferencedFieldValues', () => {
+  const field1: OHRIFormField = {
+    label: 'Visit Count',
+    type: 'obs',
+    questionOptions: {
+      rendering: 'number',
+      concept: '162576AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      answers: [],
+    },
+    id: 'htsVisitCount',
+  };
+
+  const field2: OHRIFormField = {
+    label: 'Notes',
+    type: 'obs',
+    questionOptions: {
+      rendering: 'text',
+      concept: '162576AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      answers: [],
+    },
+    id: 'notes',
+  };
+
+  const field3: OHRIFormField = {
+    label: 'Was HIV tested?',
+    type: 'obs',
+    questionOptions: {
+      rendering: 'toggle',
+      concept: '162576AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      answers: [],
+    },
+    id: 'wasHivTested',
+  };
+
+  const valuesMap = {
+    htsVisitCount: 10,
+    notes: 'Some notes',
+    wasHivTested: false,
+  };
+
+  it("should replace 'htsVisitCount' with value path", () => {
+    // setup
+    const expression = "htsVisitCount && helpFn1(htsVisitCount) && helpFn2('htsVisitCount')";
+    // replay
+    const result = linkReferencedFieldValues([field1], valuesMap, parseExpression(expression));
+    // verify
+    expect(result).toEqual(
+      'fieldValues.htsVisitCount && helpFn1(fieldValues.htsVisitCount) && helpFn2(fieldValues.htsVisitCount)',
+    );
+  });
+
+  it('should support complex expressions', () => {
+    // setup
+    const expression =
+      'htsVisitCount > 2 ? resolve(api.getByConcept(wasHivTested)) : resolve(api.call2ndApi(wasHivTested, htsVisitCount))';
+    // replay
+    const result = linkReferencedFieldValues([field1, field2, field3], valuesMap, parseExpression(expression));
+    // verify
+    expect(result).toEqual(
+      `fieldValues.htsVisitCount > 2 ? resolve(api.getByConcept('${ConceptFalse}')) : resolve(api.call2ndApi('${ConceptFalse}', fieldValues.htsVisitCount))`,
+    );
+  });
+
+  it('should ignore ref to useFieldValue', () => {
+    // setup
+    const expression =
+      "htsVisitCount > 2 ? resolve(api.getByConcept(useFieldValue('wasHivTested'))) : resolve(api.call2ndApi(wasHivTested, useFieldValue('htsVisitCount')))";
+    // replay
+    const result = linkReferencedFieldValues([field1, field2, field3], valuesMap, parseExpression(expression));
+    // verify
+    expect(result).toEqual(
+      `fieldValues.htsVisitCount > 2 ? resolve(api.getByConcept(useFieldValue('wasHivTested'))) : resolve(api.call2ndApi('${ConceptFalse}', useFieldValue('htsVisitCount')))`,
+    );
+  });
+});
+
+describe('findAndRegisterReferencedFields', () => {
+  it('should register field dependants', () => {
+    // setup
+    const expression = "linkedToCare == 'cf82933b-3f3f-45e7-a5ab-5d31aaee3da3' && !isEmpty(htsProviderRemarks)";
+    const patientIdentificationNumberField = testFields.find(f => f.id === 'patientIdentificationNumber');
+
+    // replay
+    findAndRegisterReferencedFields(
+      { value: patientIdentificationNumberField, type: 'field' },
+      parseExpression(expression),
+      testFields,
+    );
+
+    // verify
+    const linkedToCare = testFields.find(f => f.id === 'linkedToCare');
+    const htsProviderRemarks = testFields.find(f => f.id === 'htsProviderRemarks');
+    expect(linkedToCare.fieldDependants).toStrictEqual(new Set(['patientIdentificationNumber']));
+    expect(htsProviderRemarks.fieldDependants).toStrictEqual(new Set(['patientIdentificationNumber']));
   });
 });

--- a/src/utils/expression-runner.test.ts
+++ b/src/utils/expression-runner.test.ts
@@ -1,5 +1,7 @@
 import { OHRIFormField } from '../api/types';
+import { ConceptFalse } from '../constants';
 import { CommonExpressionHelpers } from './common-expression-helpers';
+import { parseExpression } from './expression-parser';
 import { checkReferenceToResolvedFragment, evaluateExpression, ExpressionContext } from './expression-runner';
 
 export const testFields: Array<OHRIFormField> = [
@@ -172,7 +174,7 @@ describe('Common expression runner - evaluateExpression', () => {
     // replay and verify
     expect(
       evaluateExpression(
-        '!isEmpty(`linkedToCare`) && isEmpty(`htsProviderRemarks`)',
+        "!isEmpty('linkedToCare') && isEmpty('htsProviderRemarks')",
         { value: allFields[1], type: 'field' },
         allFields,
         valuesMap,
@@ -190,7 +192,7 @@ describe('Common expression runner - evaluateExpression', () => {
     // replay and verify
     expect(
       evaluateExpression(
-        'includes(`referredToPreventionServices`, `88cdde2b-753b-48ac-a51a-ae5e1ab24846`) && !includes(`referredToPreventionServices`, `1691AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`)',
+        "includes('referredToPreventionServices', '88cdde2b-753b-48ac-a51a-ae5e1ab24846') && !includes('referredToPreventionServices', '1691AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')",
         { value: allFields[1], type: 'field' },
         allFields,
         valuesMap,
@@ -202,7 +204,7 @@ describe('Common expression runner - evaluateExpression', () => {
   it('should support session mode as a runtime', () => {
     expect(
       evaluateExpression(
-        'mode == `enter` && isEmpty(`htsProviderRemarks`)',
+        "mode == 'enter' && isEmpty('htsProviderRemarks')",
         { value: allFields[2], type: 'field' },
         allFields,
         valuesMap,
@@ -221,7 +223,7 @@ describe('Common expression runner - evaluateExpression', () => {
     // replay
     expect(
       evaluateExpression(
-        '!includes(`referredToPreventionServices`, `88cdde2b-753b-48ac-a51a-ae5e1ab24846`) && isEmpty(`htsProviderRemarks`)',
+        "!includes('referredToPreventionServices', '88cdde2b-753b-48ac-a51a-ae5e1ab24846') && isEmpty('htsProviderRemarks')",
         { value: allFields[4], type: 'field' },
         allFields,
         valuesMap,

--- a/src/utils/expression-runner.ts
+++ b/src/utils/expression-runner.ts
@@ -1,7 +1,6 @@
-import { ConceptFalse, ConceptTrue } from '../constants';
 import { OHRIFormField, OHRIFormPage, OHRIFormSection } from '../api/types';
-import { CommonExpressionHelpers, registerDependency } from './common-expression-helpers';
-import { parseExpression } from './expression-parser';
+import { CommonExpressionHelpers } from './common-expression-helpers';
+import { findAndRegisterReferencedFields, linkReferencedFieldValues, parseExpression } from './expression-parser';
 
 export interface FormNode {
   value: OHRIFormPage | OHRIFormSection | OHRIFormField;
@@ -17,21 +16,22 @@ export interface ExpressionContext {
 export function evaluateExpression(
   expression: string,
   node: FormNode,
-  allFields: Array<OHRIFormField>,
-  allFieldValues: Record<string, any>,
+  fields: Array<OHRIFormField>,
+  fieldValues: Record<string, any>,
   context: ExpressionContext,
 ): any {
   if (!expression?.trim()) {
     return null;
   }
-  const allFieldsKeys = allFields.map(f => f.id);
+  const allFieldsKeys = fields.map(f => f.id);
   const parts = parseExpression(expression.trim());
+  // register dependencies
+  findAndRegisterReferencedFields(node, parts, fields);
   // setup function scope
   let { mode, myValue, patient } = context;
   if (node.type === 'field' && myValue === undefined) {
-    myValue = allFieldValues[node.value['id']];
+    myValue = fieldValues[node.value['id']];
   }
-
   const {
     isEmpty,
     today,
@@ -56,13 +56,9 @@ export function evaluateExpression(
     calcGravida,
     calcDaysSinceCircumcisionProcedure,
     calcTimeDifference,
-  } = new CommonExpressionHelpers(node, patient, allFields, allFieldValues, allFieldsKeys);
+  } = new CommonExpressionHelpers(node, patient, fields, fieldValues, allFieldsKeys);
 
-  parts.forEach((part, index) => {
-    if (index % 2 == 0 && allFieldsKeys.includes(part)) {
-      expression = interpolateFieldValue(node, expression, allFields, allFieldValues, part);
-    }
-  });
+  expression = linkReferencedFieldValues(fields, fieldValues, parts);
 
   try {
     return eval(expression);
@@ -75,19 +71,21 @@ export function evaluateExpression(
 export async function evaluateAsyncExpression(
   expression: string,
   node: FormNode,
-  allFields: Array<OHRIFormField>,
-  allFieldValues: Record<string, any>,
+  fields: Array<OHRIFormField>,
+  fieldValues: Record<string, any>,
   context: ExpressionContext,
 ): Promise<any> {
   if (!expression?.trim()) {
     return null;
   }
-  const allFieldsKeys = allFields.map(f => f.id);
-  const parts = parseExpression(expression.trim());
+  const allFieldsKeys = fields.map(f => f.id);
+  let parts = parseExpression(expression.trim());
+  // register dependencies
+  findAndRegisterReferencedFields(node, parts, fields);
   // setup function scope
   let { mode, myValue, patient } = context;
   if (node.type === 'field' && myValue === undefined) {
-    myValue = allFieldValues[node.value['id']];
+    myValue = fieldValues[node.value['id']];
   }
   const {
     api,
@@ -114,14 +112,14 @@ export async function evaluateAsyncExpression(
     calcGravida,
     calcDaysSinceCircumcisionProcedure,
     calcTimeDifference,
-  } = new CommonExpressionHelpers(node, patient, allFields, allFieldValues, allFieldsKeys);
+  } = new CommonExpressionHelpers(node, patient, fields, fieldValues, allFieldsKeys);
 
+  expression = linkReferencedFieldValues(fields, fieldValues, parts);
+  // parts with resolve-able field references
+  parts = parseExpression(expression);
   const lazyFragments = [];
   parts.forEach((part, index) => {
     if (index % 2 == 0) {
-      if (allFieldsKeys.includes(part)) {
-        expression = interpolateFieldValue(node, expression, allFields, allFieldValues, part);
-      }
       if (part.startsWith('resolve(')) {
         const [refinedSubExpression] = checkReferenceToResolvedFragment(part);
         lazyFragments.push({ expression: refinedSubExpression, index });
@@ -158,46 +156,6 @@ export async function evaluateAsyncExpression(
  */
 export function resolve(lazy: Promise<any>) {
   return Promise.resolve(lazy);
-}
-
-/**
- * Interpolates the field value into the expression; This is done by replacing the field id with the field value.
- * @param fieldNode The field node
- * @param expression The expression
- * @param fields All fields
- * @param fieldValues Field values
- * @param token The field id to be replaced
- * @returns Refined expression
- */
-function interpolateFieldValue(
-  fieldNode: FormNode,
-  expression: string,
-  fields: Array<OHRIFormField>,
-  fieldValues: Record<string, any>,
-  token: string,
-): string {
-  const determinant = fields.find(field => field.id === token);
-  registerDependency(fieldNode, determinant);
-  // prep eval variables
-  let determinantValue = fieldValues[token];
-  if (determinant.questionOptions.rendering == 'toggle' && typeof determinantValue == 'boolean') {
-    determinantValue = determinantValue ? ConceptTrue : ConceptFalse;
-  }
-  if (typeof determinantValue == 'string') {
-    determinantValue = `'${determinantValue}'`;
-  }
-  const regx = new RegExp(token, 'g');
-  expression = expression.replace(regx, determinantValue);
-  return expression;
-}
-
-// For testing purposes only
-function mockAsyncFunction(value: any, delay?: number) {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve(value);
-    }, delay || 1000);
-  });
 }
 
 /**


### PR DESCRIPTION

## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [X] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [X] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR streamlines the Expression Runner by removing the necessity for manually registering interdependent fields and incorporating value interpolation within referenced helper functions. Additionally, it revitalizes the support for custom arbitrary data sources within the engine.

## Screenshots
![2023-04-25 18-59-18 2023-04-25 20_17_33](https://user-images.githubusercontent.com/26084581/234354330-8e42fae5-45bd-422e-85c9-1961c2e34498.gif)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://www.notion.so/ucsf-ighs/Add-custom-data-sources-eg-HTS-ML-a6477780a99a48b09af1990d17ec9695

