### PR TITLE
(fix) Fix validators for number and text inputs

### DIFF
--- a/src/components/inputs/text/ohri-text.component.tsx
+++ b/src/components/inputs/text/ohri-text.component.tsx
@@ -90,6 +90,8 @@ const OHRIText: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
               invalidText={errors.length && errors[0].message}
               warn={warnings.length > 0}
               warnText={warnings.length && warnings[0].message}
+              onInvalid={e => e.preventDefault()}
+              maxLength={question.questionOptions.max || TextInput.maxLength}
             />
           </div>
           {previousValueForReview && (

--- a/src/components/inputs/text/ohri-text.component.tsx
+++ b/src/components/inputs/text/ohri-text.component.tsx
@@ -90,8 +90,6 @@ const OHRIText: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
               invalidText={errors.length && errors[0].message}
               warn={warnings.length > 0}
               warnText={warnings.length && warnings[0].message}
-              onInvalid={e => e.preventDefault()}
-              maxLength={question.questionOptions.max || TextInput.maxLength}
             />
           </div>
           {previousValueForReview && (

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,2 +1,5 @@
 import '@testing-library/jest-dom/extend-expect';
 import 'jest-when';
+
+// https://github.com/jsdom/jsdom/issues/1695
+window.HTMLElement.prototype.scrollIntoView = function() {};

--- a/src/validators/ohri-form-validator.test.ts
+++ b/src/validators/ohri-form-validator.test.ts
@@ -64,7 +64,7 @@ describe('OHRIFieldValidator - validate', () => {
     expect(validationErrors).toEqual([
       {
         errCode: 'field.outOfBound',
-        message: `Field length error, field length can't be greater than ${textInputField.questionOptions.maxLength}`,
+        message: `Length should not exceed ${textInputField.questionOptions.maxLength} characters`,
         resultType: 'error',
       },
     ]);
@@ -76,7 +76,7 @@ describe('OHRIFieldValidator - validate', () => {
     expect(validationErrors).toEqual([
       {
         errCode: 'field.outOfBound',
-        message: `Field length error, field length can't be less than ${textInputField.questionOptions.minLength}`,
+        message: `Length should be at least ${textInputField.questionOptions.minLength} characters`,
         resultType: 'error',
       },
     ]);
@@ -97,7 +97,7 @@ describe('OHRIFieldValidator - validate', () => {
     expect(validationErrors).toEqual([
       {
         errCode: 'field.outOfBound',
-        message: `Field length error, field length should be between ${textInputField.questionOptions.minLength} and ${textInputField.questionOptions.maxLength}.`,
+        message: `Length should not exceed ${textInputField.questionOptions.maxLength} characters`,
         resultType: 'error',
       },
     ]);
@@ -109,7 +109,7 @@ describe('OHRIFieldValidator - validate', () => {
     expect(validationErrors).toEqual([
       {
         errCode: 'field.outOfBound',
-        message: `Field length error, field length should be between ${textInputField.questionOptions.minLength} and ${textInputField.questionOptions.maxLength}.`,
+        message: `Length should be at least ${textInputField.questionOptions.minLength} characters`,
         resultType: 'error',
       },
     ]);
@@ -137,31 +137,21 @@ describe('OHRIFieldValidator - validate', () => {
     expect(validationErrors).toEqual([
       {
         errCode: 'field.outOfBound',
-        message: `Field value can't be less than ${numberInputField.questionOptions.min}`,
+        message: `Value must be greater than ${numberInputField.questionOptions.min}`,
         resultType: 'error',
       },
     ]);
   });
 
-  it('should fail for number greater than the defined max allowed', () => {
+  it('should fail for numbers greater than the defined max allowed', () => {
     const validationErrors = OHRIFieldValidator.validate(numberInputField, 100);
 
     expect(validationErrors).toEqual([
       {
         errCode: 'field.outOfBound',
-        message: `Field value can't be greater than ${numberInputField.questionOptions.max}`,
+        message: `Value must be lower than ${numberInputField.questionOptions.max}`,
         resultType: 'error',
       },
     ]);
-  });
-
-  it('should accept value equal to min allowed', () => {
-    const validationErrors = OHRIFieldValidator.validate(numberInputField, numberInputField.questionOptions.min);
-    expect(validationErrors).toEqual(undefined);
-  });
-
-  it('should accept value equal to max allowed', () => {
-    const validationErrors = OHRIFieldValidator.validate(numberInputField, numberInputField.questionOptions.max);
-    expect(validationErrors).toEqual(undefined);
   });
 });

--- a/src/validators/ohri-form-validator.ts
+++ b/src/validators/ohri-form-validator.ts
@@ -14,19 +14,45 @@ export const OHRIFieldValidator: FieldValidator = {
         return addError(fieldRequiredErrCode, 'Field is mandatory');
       }
     }
-    if (field.questionOptions.rendering == 'number') {
-      return numberInputRangeValidator(Number(field.questionOptions.min), Number(field.questionOptions.max), value);
+    if (field.questionOptions.rendering === 'text') {
+      const minLength = field.questionOptions.minLength;
+      const maxLength = field.questionOptions.maxLength;
+
+      return textInputLengthValidator(minLength, maxLength, value.length);
     }
-    if (field.questionOptions.rendering == 'text') {
-      return textInputLengthValidator(
-        Number(field.questionOptions.minLength),
-        Number(field.questionOptions.maxLength),
-        value,
-      );
+    if (field.questionOptions.rendering === 'number') {
+      const min = Number(field.questionOptions.min);
+      const max = Number(field.questionOptions.max);
+
+      return !Number.isNaN(min) || !Number.isNaN(max) ? numberInputRangeValidator(min, max, value) : [];
     }
     return [];
   },
 };
+
+export function numberInputRangeValidator(min: number, max: number, inputValue: number) {
+  if (min && inputValue < Number(min)) {
+    return [
+      {
+        resultType: 'error',
+        errCode: fieldOutOfBoundErrCode,
+        message: `Value must be greater than ${min}`,
+      },
+    ];
+  }
+
+  if (max && inputValue > Number(max)) {
+    return [
+      {
+        resultType: 'error',
+        errCode: fieldOutOfBoundErrCode,
+        message: `Value must be lower than ${max}`,
+      },
+    ];
+  }
+
+  return [];
+}
 
 export function isEmpty(value: any): boolean {
   if (value === undefined || value === null || value === '') {
@@ -41,27 +67,26 @@ export function isEmpty(value: any): boolean {
   return false;
 }
 
-export function textInputLengthValidator(minLength: number, maxLength: number, value: string) {
-  if (minLength && maxLength && value.length >= minLength && value.length <= maxLength) {
-    return [];
-  } else if (minLength && maxLength && (value.length < minLength || value.length > maxLength)) {
-    return addError(
-      fieldOutOfBoundErrCode,
-      `Field length error, field length should be between ${minLength} and ${maxLength}.`,
-    );
-  } else if (minLength && value.length < minLength) {
-    return addError(fieldOutOfBoundErrCode, `Field length error, field length can't be less than ${minLength}`);
-  } else if (maxLength && value.length > maxLength) {
-    return addError(fieldOutOfBoundErrCode, `Field length error, field length can't be greater than ${maxLength}`);
-  }
-}
+export function textInputLengthValidator(minLength: string, maxLength: string, inputLength: number) {
+  const minLen = Number(minLength);
+  const maxLen = Number(maxLength);
 
-export function numberInputRangeValidator(min: number, max: number, value: number) {
-  if (min && value < Number(min)) {
-    return addError(fieldOutOfBoundErrCode, `Field value can't be less than ${min}`);
-  }
-  if (max && value > Number(max)) {
-    return addError(fieldOutOfBoundErrCode, `Field value can't be greater than ${max}`);
+  if (typeof inputLength === 'number' && !Number.isNaN(inputLength)) {
+    if (minLen && maxLen && inputLength >= minLen && inputLength <= maxLen) {
+      return [];
+    }
+
+    if (minLen && inputLength < minLen) {
+      return addError(fieldOutOfBoundErrCode, `Length should be at least ${minLen} characters`);
+    }
+
+    if (maxLen && inputLength > maxLen) {
+      return addError(fieldOutOfBoundErrCode, `Length should not exceed ${maxLen} characters`);
+    }
+
+    if (maxLen && minLen && inputLength < minLen && inputLength > maxLen) {
+      return addError(fieldOutOfBoundErrCode, `Length should be between ${minLen} and ${maxLen} characters`);
+    }
   }
 }
 

--- a/src/validators/ohri-form-validator.ts
+++ b/src/validators/ohri-form-validator.ts
@@ -31,7 +31,7 @@ export const OHRIFieldValidator: FieldValidator = {
 };
 
 export function numberInputRangeValidator(min: number, max: number, inputValue: number) {
-  if (min && inputValue < Number(min)) {
+  if (!Number.isNaN(min) && inputValue < min) {
     return [
       {
         resultType: 'error',
@@ -41,7 +41,7 @@ export function numberInputRangeValidator(min: number, max: number, inputValue: 
     ];
   }
 
-  if (max && inputValue > Number(max)) {
+  if (!Number.isNaN(max) && inputValue > max) {
     return [
       {
         resultType: 'error',


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue with the number and text input validators that caused the validations to fail silently. Ultimately, this issue led to forms failing to POST when saved. 
