### PR TITLE
add skip logic for answer options

### DIFF
--- a/__mocks__/forms/ohri-forms/filter-answer-options-test-form.json
+++ b/__mocks__/forms/ohri-forms/filter-answer-options-test-form.json
@@ -1,0 +1,87 @@
+{
+  "name": "Test Form",
+  "pages": [
+    {
+      "label": "Testing",
+      "sections": [
+        {
+          "label": "Testing history",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "How many times have you tested in the past?",
+              "type": "obs",
+              "id": "test_count",
+              "questionOptions": {
+                "concept": "5624AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rendering": "number"
+              },
+              "behaviours": [
+                {
+                  "intent": "*",
+                  "required": "true",
+                  "unspecified": "true",
+                  "hide": {
+                    "hideWhenExpression": "false"
+                  },
+                  "validators": []
+                }
+              ]
+            },
+            {
+              "label": "Testing Recommendations",
+              "type": "obs",
+              "id": "recommendation",
+              "questionOptions": {
+                "concept": "efc87cd5-2fd8-411c-ba52-b0d858f541e7",
+                "rendering": "select",
+                "answers": [
+                  {
+                    "concept": "160036AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Perfect testing",
+                    "hide": {
+                      "hideWhenExpression": "test_count > 5"
+                    }
+                  },
+                  {
+                    "concept": "163266AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Minimal testing",
+                    "hide": {
+                      "hideWhenExpression": "test_count > 5"
+                    }
+                  },
+                  {
+                    "concept": "52f7fc03-611b-4b62-8498-37beb2fa99ed",
+                    "label": "Not ideal",
+                    "hide": {
+                      "hideWhenExpression": "false"
+                    }
+                  },
+                  {
+                    "concept": "54b96458-6585-4c4c-a5b1-b3ca7f1be351",
+                    "label": "Un-decisive"
+                  }
+                ]
+              },
+              "behaviours": [
+                {
+                  "intent": "*",
+                  "required": "true",
+                  "hide": {
+                    "hideWhenExpression": "false"
+                  },
+                  "validators": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "availableIntents": [],
+  "processor": "EncounterFormProcessor",
+  "uuid": "da24c540-cc83-43bc-978f-c1ef180a497f",
+  "referencedForms": [],
+  "encounterType": "79c1f50f-f77d-42e2-ad2a-d29304dde2fe"
+}

--- a/src/components/encounter/ohri-encounter-form.component.tsx
+++ b/src/components/encounter/ohri-encounter-form.component.tsx
@@ -170,6 +170,20 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
           } else {
             field.isHidden = false;
           }
+          field.questionOptions.answers
+            ?.filter(answer => !isEmpty(answer.hide?.hideWhenExpression))
+            .forEach(answer => {
+              answer.isHidden = evaluateExpression(
+                answer.hide.hideWhenExpression,
+                { value: field, type: 'field' },
+                flattenedFields,
+                tempInitialValues,
+                {
+                  mode: sessionMode,
+                  patient,
+                },
+              );
+            });
           if (typeof field.readonly == 'string' && field.readonly?.split(' ')?.length > 1) {
             // needed to store the expression for further evaluations
             field['readonlyExpression'] = field.readonly;
@@ -495,6 +509,20 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
           evalHide({ value: dependant, type: 'field' }, fields, { ...values, [fieldName]: value });
           voidObsValueOnFieldHidden(dependant, obsGroupsToVoid, setFieldValue);
         }
+        dependant?.questionOptions.answers
+          ?.filter(answer => !isEmpty(answer.hide?.hideWhenExpression))
+          .forEach(answer => {
+            answer.isHidden = evaluateExpression(
+              answer.hide?.hideWhenExpression,
+              { value: dependant, type: 'field' },
+              fields,
+              { ...values, [fieldName]: value },
+              {
+                mode: sessionMode,
+                patient,
+              },
+            );
+          });
         // evaluate readonly
         if (!dependant.isHidden && dependant['readonlyExpression']) {
           dependant.readonly = evaluateExpression(

--- a/src/components/group/ohri-obs-group.component.tsx
+++ b/src/components/group/ohri-obs-group.component.tsx
@@ -41,7 +41,7 @@ export const OHRIObsGroup: React.FC<ObsGroupProps> = ({ question, onChange, dele
             {supportsUnspecified(field) ? (
               <>
                 {questionFragment}
-                <OHRIUnspecified question={field} />
+                <OHRIUnspecified question={field} onChange={onChange} handler={getHandler(field.type)} />
               </>
             ) : (
               questionFragment

--- a/src/components/inputs/multi-select/ohri-multi-select.component.tsx
+++ b/src/components/inputs/multi-select/ohri-multi-select.component.tsx
@@ -41,12 +41,14 @@ export const OHRIMultiSelect: React.FC<OHRIFormFieldProps> = ({ question, onChan
     }
   }, [question['submission']]);
 
-  const questionItems = question.questionOptions.answers.map((option, index) => ({
-    id: `${question.id}-${option.concept}`,
-    concept: option.concept,
-    label: option.label,
-    key: index,
-  }));
+  const questionItems = question.questionOptions.answers
+    .filter(answer => !answer.isHidden)
+    .map((answer, index) => ({
+      id: `${question.id}-${answer.concept}`,
+      concept: answer.concept,
+      label: answer.label,
+      key: index,
+    }));
 
   const initiallySelectedQuestionItems = [];
   questionItems.forEach(item => {

--- a/src/components/inputs/radio/ohri-radio.component.tsx
+++ b/src/components/inputs/radio/ohri-radio.component.tsx
@@ -79,16 +79,18 @@ const OHRIRadio: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }
             valueSelected={field.value}
             onChange={handleChange}
             orientation="vertical">
-            {question.questionOptions.answers.map((answer, index) => {
-              return (
-                <RadioButton
-                  id={`${question.id}-${answer.label}`}
-                  labelText={answer.label}
-                  value={answer.concept}
-                  key={index}
-                />
-              );
-            })}
+            {question.questionOptions.answers
+              .filter(answer => !answer.isHidden)
+              .map((answer, index) => {
+                return (
+                  <RadioButton
+                    id={`${question.id}-${answer.label}`}
+                    labelText={answer.label}
+                    value={answer.concept}
+                    key={index}
+                  />
+                );
+              })}
           </RadioButtonGroup>
           {(!isFieldRequiredError && errors?.length > 0) ||
             (warnings.length > 0 && (

--- a/src/components/inputs/select/ohri-dropdown.component.tsx
+++ b/src/components/inputs/select/ohri-dropdown.component.tsx
@@ -38,7 +38,9 @@ const OHRIDropdown: React.FC<OHRIFormFieldProps> = ({ question, onChange, handle
     return answer?.label;
   };
   useEffect(() => {
-    setItems(question.questionOptions.answers.map(item => item.value || item.concept));
+    setItems(
+      question.questionOptions.answers.filter(answer => !answer.isHidden).map(item => item.value || item.concept),
+    );
   }, [question.questionOptions.answers]);
 
   useEffect(() => {
@@ -78,7 +80,9 @@ const OHRIDropdown: React.FC<OHRIFormFieldProps> = ({ question, onChange, handle
             id={question.id}
             titleText={question.label}
             label="Choose an option"
-            items={items}
+            items={question.questionOptions.answers
+              .filter(answer => !answer.isHidden)
+              .map(item => item.value || item.concept)}
             itemToString={itemToString}
             selectedItem={field.value}
             onChange={({ selectedItem }) => handleChange(selectedItem)}

--- a/src/components/inputs/unspecified/ohri-unspecified.component.tsx
+++ b/src/components/inputs/unspecified/ohri-unspecified.component.tsx
@@ -3,17 +3,17 @@ import { Checkbox } from '@carbon/react';
 import { useField } from 'formik';
 import { OHRIFormContext } from '../../../ohri-form-context';
 import { OHRIFieldValidator } from '../../../validators/ohri-form-validator';
-import { OHRIFormField } from '../../../api/types';
+import { OHRIFormFieldProps, SessionMode } from '../../../api/types';
 import { isTrue } from '../../../utils/boolean-utils';
 import styles from './ohri-unspecified.scss';
 
-export const OHRIUnspecified: React.FC<{
-  question: OHRIFormField;
-}> = ({ question }) => {
+export const OHRIUnspecified: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }) => {
   const [field, meta] = useField(`${question.id}-unspecified`);
   const { setFieldValue, encounterContext } = React.useContext(OHRIFormContext);
   const [previouslyUnspecified, setPreviouslyUnspecified] = useState(false);
   const hideCheckBox = encounterContext.sessionMode == 'view';
+  const [errors, setErrors] = useState([]);
+  const [warnings, setWarnings] = useState([]);
 
   useEffect(() => {
     if (field.value) {
@@ -42,6 +42,13 @@ export const OHRIUnspecified: React.FC<{
   }, [field.value]);
 
   useEffect(() => {
+    if (question['submission']) {
+      question['submission'].errors && setErrors(question['submission'].errors);
+      question['submission'].warnings && setWarnings(question['submission'].warnings);
+    }
+  }, [question['submission']]);
+
+  useEffect(() => {
     if (question.value) {
       setFieldValue(`${question.id}-unspecified`, false);
     }
@@ -49,6 +56,8 @@ export const OHRIUnspecified: React.FC<{
 
   const handleOnChange = useCallback(value => {
     setFieldValue(`${question.id}-unspecified`, value.target.checked);
+    onChange(question.id, field.value, setErrors, setWarnings);
+    question.value = handler?.handleFieldSubmission(question, field.value, encounterContext);
   }, []);
 
   return (

--- a/src/components/inputs/unspecified/ohri-unspecified.test.tsx
+++ b/src/components/inputs/unspecified/ohri-unspecified.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { Formik, Form } from 'formik';
 import React from 'react';
 import { OHRIFormField, EncounterContext, OHRIFormContext } from '../../..';
+import { ObsSubmissionHandler } from '../../../submission-handlers/base-handlers';
 import { OHRIUnspecified } from './ohri-unspecified.component';
 
 const question: OHRIFormField = {
@@ -47,7 +48,7 @@ const renderForm = intialValues => {
               isFieldInitializationComplete: true,
               isSubmitting: false,
             }}>
-            <OHRIUnspecified question={question} />
+            <OHRIUnspecified question={question} onChange={jest.fn()} handler={ObsSubmissionHandler} />
           </OHRIFormContext.Provider>
         </Form>
       )}

--- a/src/components/section/ohri-form-section.component.tsx
+++ b/src/components/section/ohri-form-section.component.tsx
@@ -39,7 +39,7 @@ const OHRIFormSection = ({ fields, onFieldChange }) => {
               return supportsUnspecified(field) && field.questionOptions.rendering != 'group' ? (
                 <div key={index}>
                   {qnFragment}
-                  <OHRIUnspecified question={field} />
+                  <OHRIUnspecified question={field} onChange={onFieldChange} handler={getHandler(field.type)} />
                 </div>
               ) : (
                 <div key={index}>{qnFragment}</div>

--- a/src/ohri-form.component.test.tsx
+++ b/src/ohri-form.component.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent, screen, cleanup, act } from '@testing-library/react';
+import { render, fireEvent, screen, cleanup, act, getByText } from '@testing-library/react';
 import { when } from 'jest-when';
 import React from 'react';
 import OHRIForm from './ohri-form.component';
@@ -6,6 +6,7 @@ import hts_poc_1_1 from '../__mocks__/packages/hiv/forms/hts_poc/1.1.json';
 import bmi_form from '../__mocks__/forms/ohri-forms/bmi-test-form.json';
 import bsa_form from '../__mocks__/forms/ohri-forms/bsa-test-form.json';
 import edd_form from '../__mocks__/forms/ohri-forms/edd-test-form.json';
+import filter_answer_options_form from '../__mocks__/forms/ohri-forms/filter-answer-options-test-form.json';
 import next_visit_form from '../__mocks__/forms/ohri-forms/next-visit-test-form.json';
 import months_on_art_form from '../__mocks__/forms/ohri-forms/months-on-art-form.json';
 import age_validation_form from '../__mocks__/forms/ohri-forms/age-validation-form.json';
@@ -128,6 +129,33 @@ describe('OHRI Forms:', () => {
 
   describe('Form submission', () => {
     // TODO: Fillup test suite
+  });
+
+  describe('Filter Answer Options', () => {
+    it('should filter dropdown options based on value in count input field', async () => {
+      //setup
+      await act(async () => renderForm(null, filter_answer_options_form));
+      const recommendationDropdown = await findSelectInput(screen, 'Testing Recommendations');
+      const testCountField = await findNumberInput(screen, 'How many times have you tested in the past?');
+      // open dropdown
+      fireEvent.click(recommendationDropdown);
+      expect(screen.queryByRole('option', { name: /Perfect testing/i })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /Minimal testing/i })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /Un-decisive/i })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /Not ideal/i })).toBeInTheDocument();
+      // close dropdown
+      fireEvent.click(recommendationDropdown);
+      // provide a value greater than 5
+      fireEvent.blur(testCountField, { target: { value: '6' } });
+      // re-open dropdown
+      fireEvent.click(recommendationDropdown);
+      // verify
+      expect(testCountField.value).toBe('6');
+      expect(screen.queryByRole('option', { name: /Perfect testing/i })).toBeNull();
+      expect(screen.queryByRole('option', { name: /Minimal testing/i })).toBeNull();
+      expect(screen.queryByRole('option', { name: /Un-decisive/i })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /Not ideal/i })).toBeInTheDocument();
+    });
   });
 
   describe('Calcuated values', () => {


### PR DESCRIPTION
This PR adds skip logic to answer options i.e answer options in a drop down list, radio buttons or checkboxes can be hidden or shown based on answers in other questions.
Implementation:

```
"answers":[
                          {
                             "concept":"160036AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                             "label":"Transfer out",
                             "hide": {
                              "hideWhenExpression": "gravida > 2 && gravida <= 5"
                             }
                          },
                          {
                             "concept":"163266AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                             "label":"This facility",
                             "hide": {
                              "hideWhenExpression": "gravida > 5"
                             }
                          },
                          {
                             "concept":"52f7fc03-611b-4b62-8498-37beb2fa99ed",
                             "label":"In Transit",
                             "hide": {
                              "hideWhenExpression": "gravida > 5"
                             }
                          },
                          {
                             "concept":"54b96458-6585-4c4c-a5b1-b3ca7f1be351",
                             "label":"Missing"
                          }
                       ]
```
The PR also fixes a minor bug of invoking the onChange function on a field whenever it's corresponding unspecified field is toggled.

https://user-images.githubusercontent.com/12844964/234839075-31e88cff-4fe1-4c2d-a5f5-d49584116d21.mov





