### PR TITLE
Default to section hide expression without behaviours

### DIFF
--- a/src/utils/forms-loader.ts
+++ b/src/utils/forms-loader.ts
@@ -166,7 +166,7 @@ export function applyFormIntent(intent, originalJson, parentOverrides?: Array<Be
         section.hide = secBehaviour?.hide;
       } else {
         const fallBackBehaviour = section.behaviours?.find(behaviour => behaviour.intent === '*');
-        section.hide = fallBackBehaviour?.hide;
+        section.hide = fallBackBehaviour?.hide ?? section.hide;
       }
 
       // filter section-level markdown behaviour


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This ensures the form sections use the specified hide expressions when behaviours haven't been specified

## Screenshots


https://user-images.githubusercontent.com/15266028/234874081-5cf09788-50ad-4aa3-b8e4-2e6a08d1211b.mov


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
