### PR TITLE
(fix) fix bug on submitting a form

### DIFF
--- a/src/components/encounter/ohri-encounter-form.tsx
+++ b/src/components/encounter/ohri-encounter-form.tsx
@@ -311,9 +311,8 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
         .filter(field => !field.isParentHidden && !field.disabled && !field.isHidden && !isTrue(field.readonly))
         .filter(field => field['submission']?.unspecified != true)
         .forEach(field => {
-          const errors = OHRIFieldValidator.validate(field, values[field.id]).filter(
-            error => error.resultType == 'error',
-          );
+          const errors =
+            OHRIFieldValidator.validate(field, values[field.id]).filter(error => error.resultType == 'error') ?? [];
           if (errors.length) {
             errorFields.push(field);
             field['submission'] = {

--- a/src/validators/ohri-form-validator.test.ts
+++ b/src/validators/ohri-form-validator.test.ts
@@ -88,7 +88,7 @@ describe('OHRIFieldValidator - validate', () => {
       'super text super text super text',
     );
 
-    expect(validationErrors).toEqual(undefined);
+    expect(validationErrors).toEqual([]);
   });
 
   it('should fail for text length greater than the max defined length', () => {

--- a/src/validators/ohri-form-validator.ts
+++ b/src/validators/ohri-form-validator.ts
@@ -18,7 +18,7 @@ export const OHRIFieldValidator: FieldValidator = {
       const minLength = field.questionOptions.minLength;
       const maxLength = field.questionOptions.maxLength;
 
-      return textInputLengthValidator(minLength, maxLength, value.length);
+      return textInputLengthValidator(minLength, maxLength, value.length) ?? [];
     }
     if (field.questionOptions.rendering === 'number') {
       const min = Number(field.questionOptions.min);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This is an attempt to fix a bug while submitting a form. This error causes the validation to fail silently without a shouting console error as shown in the picture below. The root cause being that while looping over the error array on the validate function, in  `OHRIFieldValidator` it doesn't return an error for the case of text length validator. This causes the validate function to try loop over an object that isn't an array therefore failing silently making it hard to pick. Hoping this resolves this painful bug.

## Screenshots
![Kapture 2023-04-27 at 23 58 25](https://user-images.githubusercontent.com/28008754/234990581-55bd7272-edd7-424d-942a-13509c26a0bd.gif)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
