### PR TITLE
(feat) Various tweaks and improvements

### DIFF
--- a/src/components/encounter/ohri-encounter-form.component.tsx
+++ b/src/components/encounter/ohri-encounter-form.component.tsx
@@ -284,7 +284,11 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
   useEffect(() => {
     if (invalidFields?.length) {
       setPagesWithErrors(findPagesWithErrors(scrollablePages, invalidFields));
+
       switch (invalidFields[0].questionOptions.rendering) {
+        case 'date':
+          scrollIntoView(invalidFields[0].id, false);
+          break;
         case 'radio':
           const firstRadioGroupMemberDomId = `${invalidFields[0].id}-${invalidFields[0].questionOptions.answers[0].label}`;
           scrollIntoView(firstRadioGroupMemberDomId, true);

--- a/src/components/inputs/content-switcher/ohri-content-switcher.component.tsx
+++ b/src/components/inputs/content-switcher/ohri-content-switcher.component.tsx
@@ -18,23 +18,24 @@ export const OHRIContentSwitcher: React.FC<OHRIFormFieldProps> = ({ question, on
     if (question['submission']?.errors) {
       setErrors(question['submission']?.errors);
     }
-  }, [question['submission']]);
+  }, [question]);
 
   const handleChange = value => {
     setFieldValue(question.id, value?.name);
     onChange(question.id, value?.name, setErrors, null);
     question.value = handler?.handleFieldSubmission(question, value?.name, encounterContext);
   };
+
   const selectedIndex = useMemo(
     () => question.questionOptions.answers.findIndex(option => option.concept == field.value),
-    [field.value],
+    [field.value, question.questionOptions.answers],
   );
 
   useEffect(() => {
     getConceptNameAndUUID(question.questionOptions.concept).then(conceptTooltip => {
       setConceptName(conceptTooltip);
     });
-  }, [conceptName]);
+  }, [conceptName, question.questionOptions.concept]);
 
   const isInline = useMemo(() => {
     if (encounterContext.sessionMode == 'view' || isTrue(question.readonly)) {

--- a/src/components/inputs/location/ohri-encounter-location.component.tsx
+++ b/src/components/inputs/location/ohri-encounter-location.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Dropdown } from '@carbon/react';
 import { useField } from 'formik';
 import { createErrorHandler } from '@openmrs/esm-framework';
@@ -12,7 +12,7 @@ import styles from './ohri-encounter-location.scss';
 
 export const OHRIEncounterLocationPicker: React.FC<{ question: OHRIFormField; onChange: any }> = ({ question }) => {
   const [field, meta] = useField(question.id);
-  const { setEncounterLocation, setFieldValue, encounterContext } = React.useContext(OHRIFormContext);
+  const { setEncounterLocation, setFieldValue, encounterContext } = useContext(OHRIFormContext);
   const [locations, setLocations] = useState([]);
   const [conceptName, setConceptName] = useState('Loading...');
 

--- a/src/components/previous-value-review/previous-value-review.component.tsx
+++ b/src/components/previous-value-review/previous-value-review.component.tsx
@@ -4,13 +4,16 @@ import { useTranslation } from 'react-i18next';
 import { OHRIValueDisplay } from '../value/ohri-value.component';
 import styles from './previous-value-review.scss';
 
-export const PreviousValueReview: React.FC<{
-  value: any;
+type Props = {
+  value: string;
   displayText: string;
-  setValue: (value: any) => void;
+  setValue: (value) => void;
   hideHeader?: boolean;
-}> = ({ value, displayText, setValue, hideHeader }) => {
+};
+
+export const PreviousValueReview: React.FC<Props> = ({ value, displayText, setValue, hideHeader }) => {
   const { t } = useTranslation();
+
   return (
     <div className={styles.formField}>
       {!hideHeader && <span className="cds--label">{t('previousValue', 'Previous value')}</span>}

--- a/src/components/repeat/ohri-repeat.component.tsx
+++ b/src/components/repeat/ohri-repeat.component.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { FormGroup, Button } from '@carbon/react';
 import { Add, TrashCan } from '@carbon/react/icons';
 import { useFormikContext } from 'formik';
+import { useTranslation } from 'react-i18next';
 import cloneDeep from 'lodash-es/cloneDeep';
 import dayjs from 'dayjs';
 import { ConceptTrue } from '../../constants';
@@ -61,6 +62,7 @@ export const showAddButton = (repeatOptions: { limit?: string }, counter: number
 };
 
 export const OHRIRepeat: React.FC<OHRIFormFieldProps> = ({ question, onChange }) => {
+  const { t } = useTranslation();
   const [questions, setQuestions] = useState([question]);
   const { fields, encounterContext, obsGroupsToVoid } = React.useContext(OHRIFormContext);
   const { values, setValues } = useFormikContext();
@@ -211,13 +213,14 @@ export const OHRIRepeat: React.FC<OHRIFormFieldProps> = ({ question, onChange })
         {showAddButton(question.questionOptions.repeatOptions, counter) && (
           <Button
             renderIcon={() => <Add size={16} />}
-            kind="ghost"
+            className={styles.repeatButton}
+            kind="tertiary"
             onClick={() => {
               const nextCount = counter + 1;
               handleAdd(nextCount, null);
               setCounter(nextCount);
             }}>
-            {question.questionOptions.repeatOptions?.addText || 'Add'}
+            <span>{question.questionOptions.repeatOptions?.addText || `${t('add', 'Add')}`}</span>
           </Button>
         )}
       </div>,

--- a/src/components/section-collapsible-toggle/ohri-section-collapsible-toggle.component.tsx
+++ b/src/components/section-collapsible-toggle/ohri-section-collapsible-toggle.component.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Toggle } from '@carbon/react';
 import { useExtensionSlotMeta } from '@openmrs/esm-framework';
 import styles from './ohri-section-collapsible-toggle.scss';
 
 const OHRISectionCollapsibleToggle = () => {
+  const { t } = useTranslation();
   const metas = useExtensionSlotMeta('patient-chart-workspace-header-slot');
   const callBack = metas['ohri-form-header-toggle-ext']?.handleCollapse;
 
@@ -18,8 +20,8 @@ const OHRISectionCollapsibleToggle = () => {
         aria-label="toggle button"
         defaultToggled
         id="collapsable-toggle"
-        labelA=""
-        labelB=""
+        labelA={t('expandAll', 'Expand all')}
+        labelB={t('collapseAll', 'Collapse all')}
         onToggle={toggleCollapsedStatus}
       />
     </div>

--- a/src/components/sidebar/ohri-form-sidebar.component.tsx
+++ b/src/components/sidebar/ohri-form-sidebar.component.tsx
@@ -23,7 +23,7 @@ function OHRIFormSidebar({
     if (defaultPage && [...scrollablePages].find(({ label, isHidden }) => label === defaultPage && !isHidden)) {
       scrollIntoView(joinWord(defaultPage));
     }
-  }, [defaultPage]);
+  }, [defaultPage, scrollablePages]);
 
   const joinWord = value => {
     return value.replace(/\s/g, '');

--- a/src/components/warning-modal.component.tsx
+++ b/src/components/warning-modal.component.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Button, ComposedModal, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
+
+type Props = {
+  onClose: () => void;
+  onShowWarningModal: (showWarningModal: boolean) => void;
+  t: (key: string, fallback: string) => string;
+};
+
+const WarningModal: React.FC<Props> = ({ onClose, onShowWarningModal, t }) => {
+  return (
+    <ComposedModal preventCloseOnClickOutside open={true} onClose={() => onShowWarningModal(false)}>
+      <ModalHeader title={t('discardChanges', 'Discard changes?')}></ModalHeader>
+      <ModalBody>
+        <p>
+          {t(
+            'discardWarningText',
+            'The changes you made to this form have not been saved. Are you sure you want to discard them?',
+          )}
+        </p>
+      </ModalBody>
+      <ModalFooter>
+        <Button kind="secondary" onClick={() => onShowWarningModal(false)}>
+          {t('cancel', 'Cancel')}
+        </Button>
+        <Button kind="danger" onClick={onClose}>
+          {t('confirm', 'Confirm')}
+        </Button>
+      </ModalFooter>
+    </ComposedModal>
+  );
+};
+
+export default WarningModal;

--- a/src/hooks/useFormJson.tsx
+++ b/src/hooks/useFormJson.tsx
@@ -26,14 +26,14 @@ export function useFormJson(formUuid: string, rawFormJson: any, encounterUuid: s
   };
 }
 /**
- * Fetches a form JSON from OpenMRS and recursively fetches all subforms if they exist.
+ * Fetches a form JSON from OpenMRS and recursively fetches its subforms if they available.
  *
  * If `rawFormJson` is provided, it will be used as the raw form JSON object. Otherwise, the form JSON will be fetched from OpenMRS using the `formIdentifier` parameter.
  *
  * @param rawFormJson The raw form JSON object to be used if `formIdentifier` is not provided.
  * @param formIdentifier The UUID or name of the form to be fetched from OpenMRS if `rawFormJson` is not provided.
  * @param formSessionIntent An optional parameter that represents the current intent.
- * @returns A well-built form object that includes any subforms.
+ * @returns A well-built form object that might include subforms.
  */
 export async function loadFormJson(
   formIdentifier: string,

--- a/src/hooks/useFormsConfig.tsx
+++ b/src/hooks/useFormsConfig.tsx
@@ -21,7 +21,7 @@ export function useFormsConfig(moduleName: string, configPath: string) {
         setConfig({ config, ...get(c, configPath, config) });
       });
     }
-  }, [moduleName, configPath]);
+  }, [moduleName, configPath, config]);
 
   return config;
 }

--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -26,6 +26,7 @@ import { usePatientData } from './hooks/usePatientData';
 import LinearLoader from './components/loaders/linear-loader.component';
 import LoadingIcon from './components/loaders/loading.component';
 import OHRIFormSidebar from './components/sidebar/ohri-form-sidebar.component';
+import WarningModal from './components/warning-modal.component';
 import styles from './ohri-form.scss';
 
 interface OHRIFormProps {
@@ -164,30 +165,6 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
     reportError(patientError, t);
   }, [patientError, t]);
 
-  const WarningModal = () => {
-    return (
-      <ComposedModal preventCloseOnClickOutside open={true} onClose={() => setShowWarningModal(false)}>
-        <ModalHeader title={t('discardChanges', 'Discard changes?')}></ModalHeader>
-        <ModalBody>
-          <p className={styles.messageBody}>
-            {t(
-              'discardWarningText',
-              'The changes you made to this form have not been saved. Are you sure you want to discard them?',
-            )}
-          </p>
-        </ModalBody>
-        <ModalFooter>
-          <Button kind="secondary" onClick={() => setShowWarningModal(false)}>
-            {t('cancel', 'Cancel')}
-          </Button>
-          <Button kind="danger" onClick={handleClose}>
-            {t('confirm', 'Confirm')}
-          </Button>
-        </ModalFooter>
-      </ComposedModal>
-    );
-  };
-
   const handleFormSubmit = (values: Record<string, any>) => {
     // validate the form and its subforms (when present)
     let isSubmittable = true;
@@ -206,7 +183,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
 
       Promise.all(submissions)
         .then(async results => {
-          if (mode == 'edit') {
+          if (mode === 'edit') {
             showToast({
               description: t('updatedRecordDescription', 'The patient encounter was updated'),
               title: t('updatedRecord', 'Record updated'),
@@ -262,12 +239,14 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
         setIsFormTouched(props.dirty);
 
         return (
-          <Form className={`cds--form no-padding ${styles.ohriForm}`} ref={ref}>
+          <Form style={{ outline: '2px solid cyan' }} className={`cds--form no-padding ${styles.ohriForm}`} ref={ref}>
             {isLoadingPatient || isLoadingFormJson ? (
               <LoadingIcon />
             ) : (
               <div className={styles.ohriFormContainer}>
-                {showWarningModal ? <WarningModal /> : null}
+                {showWarningModal ? (
+                  <WarningModal onClose={handleClose} onShowWarningModal={setShowWarningModal} t={t} />
+                ) : null}
                 {isLoadingFormDependencies && (
                   <div className={styles.loader}>
                     <LinearLoader />
@@ -300,7 +279,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                     )}
                     <div
                       className={`${styles.formContentBody}
-                    ${workspaceLayout == 'minimized' ? `${styles.minifiedFormContentBody}` : ''}
+                    ${workspaceLayout === 'minimized' ? `${styles.minifiedFormContentBody}` : ''}
                   `}>
                       <OHRIEncounterForm
                         formJson={refinedFormJson}
@@ -325,7 +304,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                         isSubmitting={isSubmitting}
                       />
                     </div>
-                    {workspaceLayout == 'minimized' && (
+                    {workspaceLayout === 'minimized' && (
                       <ButtonSet className={styles.minifiedButtons}>
                         <Button
                           kind="secondary"
@@ -338,9 +317,9 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                             onCancel && onCancel();
                             handleClose && handleClose();
                           }}>
-                          {mode == 'view' ? 'Close' : 'Cancel'}
+                          {mode === 'view' ? 'Close' : 'Cancel'}
                         </Button>
-                        <Button type="submit" disabled={mode == 'view' || isSubmitting}>
+                        <Button type="submit" disabled={mode === 'view' || isSubmitting}>
                           {isSubmitting ? (
                             <InlineLoading description={t('submitting', 'Submitting') + '...'} />
                           ) : (

--- a/src/utils/ohri-sidebar.ts
+++ b/src/utils/ohri-sidebar.ts
@@ -1,11 +1,12 @@
-export function scrollIntoView(viewId: string, toFocus: boolean = false) {
+export function scrollIntoView(viewId: string, shouldFocus: boolean = false) {
   const currentElement = document.getElementById(viewId);
   currentElement?.scrollIntoView({
     behavior: 'smooth',
     block: 'start',
     inline: 'start',
   });
-  if (toFocus) {
+
+  if (shouldFocus) {
     currentElement?.focus();
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR makes various fixes and improvements. These include:

- Fixing a situation where date inputs with invalid content trap focus and prevent the user from clicking elsewhere on the page.
- Adds some padding around radio button inputs.
- Tweaks the appearance of the `Previous` value input - changing its label to read `Previous value` and adjusting elements in the UI.
- Rendering a loading spinner when the form is POSTing to the server.
- Render a warning modal when a user fills a form and then (inadvertently or otherwise) tries to navigate away from the page. This modal notifies the user that they might lose their changes by navigating away.