### PR TITLE
(feat) Support for conditionally hiding `pages`

### DIFF
--- a/src/components/encounter/ohri-encounter-form.tsx
+++ b/src/components/encounter/ohri-encounter-form.tsx
@@ -556,9 +556,16 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
       }}>
       <InstantEffect effect={addScrollablePages} />
       {form.pages.map((page, index) => {
-        if (isTrue(page.isHidden)) {
+        const pageHasNoVisibleContent =
+          page.sections.every(section => section.isHidden) ||
+          page.sections.every(section => section.questions.every(question => question.isHidden)) ||
+          isTrue(page.isHidden);
+
+        if (pageHasNoVisibleContent) {
+          console.info(`The page "${page.label}" has no visible questions. Its sections will not be rendered.`);
           return null;
         }
+
         if (isTrue(page.isSubform) && page.subform?.form) {
           if (sessionMode != 'enter' && !page.subform?.form.encounter) {
             return null;

--- a/src/components/encounter/ohri-encounter-form.tsx
+++ b/src/components/encounter/ohri-encounter-form.tsx
@@ -562,7 +562,6 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
           isTrue(page.isHidden);
 
         if (pageHasNoVisibleContent) {
-          console.info(`The page "${page.label}" has no visible questions. Its sections will not be rendered.`);
           return null;
         }
 

--- a/src/components/page/ohri-form-page.tsx
+++ b/src/components/page/ohri-form-page.tsx
@@ -12,14 +12,6 @@ function OHRIFormPage({ page, onFieldChange, setSelectedPage, isCollapsed }) {
     setSelectedPage(elementID);
   };
 
-  const pageHasNoVisibleQuestions = page.sections.every(section =>
-    section.questions.every(question => question.isHidden),
-  );
-
-  if (pageHasNoVisibleQuestions) {
-    console.info(`The page "${page.label}" has no visible questions. Its sections will not be rendered.`);
-  }
-
   const visibleSections = page.sections.filter(section => {
     const hasVisibleQuestions = section.questions.some(question => !isTrue(question.isHidden));
     return !isTrue(section.isHidden) && hasVisibleQuestions;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Adds support for conditionally hiding `pages` if:

- All the `sections` in the `page` definition have `isHidden` set to a "true".
- All the `questions` of all the `sections` in the page have `isHidden` set to "true".
- The page's `isHidden` property is set to "true".

## Screenshots

> **Before**: All the questions in the `Examination Details` section are hidden by validation rules, which means the page shouldn't get displayed at all

<img width="1913" alt="Screenshot 2023-04-28 at 11 13 05" src="https://user-images.githubusercontent.com/2032761/235094270-e410fb64-f764-45ba-b61a-c76014a8b91c.png">


> **After**: The `Examination Details` section is appropriately hidden

<img width="1012" alt="Screenshot 2023-04-28 at 11 21 04" src="https://user-images.githubusercontent.com/2032761/235095249-3d3d809a-6e1e-4819-ae41-e03bb038dcc1.png">
