### PR TITLE
(enhc) Add ability to provide `age` and `sex` to the evaluation context

### DIFF
--- a/src/components/encounter/ohri-encounter-form.tsx
+++ b/src/components/encounter/ohri-encounter-form.tsx
@@ -181,8 +181,6 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
               {
                 mode: sessionMode,
                 patient,
-                age: patient?.age,
-                sex: patient.sex,
               },
             );
           }
@@ -236,8 +234,6 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
     const isHidden = evaluateExpression(value['hide']?.hideWhenExpression, node, allFields, allValues, {
       mode: sessionMode,
       patient,
-      age: patient?.age,
-      sex: patient.sex,
     });
     node.value.isHidden = isHidden;
     if (type == 'field' && node.value?.questions?.length) {
@@ -469,8 +465,6 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
             {
               mode: sessionMode,
               patient,
-              age: patient?.age,
-              sex: patient.sex,
             },
           ).then(result => {
             result = isEmpty(result) ? '' : result;
@@ -494,8 +488,6 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
             {
               mode: sessionMode,
               patient,
-              age: patient?.age,
-              sex: patient.sex,
             },
           );
         }

--- a/src/components/encounter/ohri-encounter-form.tsx
+++ b/src/components/encounter/ohri-encounter-form.tsx
@@ -181,6 +181,8 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
               {
                 mode: sessionMode,
                 patient,
+                age: patient?.age,
+                sex: patient.sex,
               },
             );
           }
@@ -234,6 +236,8 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
     const isHidden = evaluateExpression(value['hide']?.hideWhenExpression, node, allFields, allValues, {
       mode: sessionMode,
       patient,
+      age: patient?.age,
+      sex: patient.sex,
     });
     node.value.isHidden = isHidden;
     if (type == 'field' && node.value?.questions?.length) {
@@ -465,6 +469,8 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
             {
               mode: sessionMode,
               patient,
+              age: patient?.age,
+              sex: patient.sex,
             },
           ).then(result => {
             result = isEmpty(result) ? '' : result;
@@ -488,6 +494,8 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
             {
               mode: sessionMode,
               patient,
+              age: patient?.age,
+              sex: patient.sex,
             },
           );
         }

--- a/src/hooks/usePatientData.tsx
+++ b/src/hooks/usePatientData.tsx
@@ -14,10 +14,19 @@ function calculateAge(birthDate: Date): number {
   }
 }
 
+const patientGenderMap = {
+  female: 'F',
+  male: 'M',
+  other: 'O',
+  unknown: 'U',
+};
+
 export const usePatientData = patientUuid => {
   const { patient, isLoading: isLoadingPatient, error: patientError } = usePatient(patientUuid);
-  if(patient && !isLoadingPatient) {
+  if (patient && !isLoadingPatient) {
+    // This is to support backward compatibility with the AMPATH JSON format
     patient['age'] = calculateAge(new Date(patient?.birthDate));
+    patient['sex'] = patientGenderMap[patient.gender] ?? 'U';
   }
   return { patient, isLoadingPatient, patientError };
 };

--- a/src/utils/expression-runner.ts
+++ b/src/utils/expression-runner.ts
@@ -11,6 +11,8 @@ export interface ExpressionContext {
   mode: 'enter' | 'edit' | 'view';
   myValue?: any;
   patient: any;
+  sex: string;
+  age: number;
 }
 
 export function evaluateExpression(
@@ -28,7 +30,7 @@ export function evaluateExpression(
   // register dependencies
   findAndRegisterReferencedFields(node, parts, fields);
   // setup function scope
-  let { mode, myValue, patient } = context;
+  let { mode, myValue, patient, age, sex } = context;
   if (node.type === 'field' && myValue === undefined) {
     myValue = fieldValues[node.value['id']];
   }

--- a/src/utils/expression-runner.ts
+++ b/src/utils/expression-runner.ts
@@ -11,8 +11,6 @@ export interface ExpressionContext {
   mode: 'enter' | 'edit' | 'view';
   myValue?: any;
   patient: any;
-  sex: string;
-  age: number;
 }
 
 export function evaluateExpression(
@@ -30,7 +28,8 @@ export function evaluateExpression(
   // register dependencies
   findAndRegisterReferencedFields(node, parts, fields);
   // setup function scope
-  let { mode, myValue, patient, age, sex } = context;
+  let { mode, myValue, patient } = context;
+  const { sex, age } = patient;
   if (node.type === 'field' && myValue === undefined) {
     myValue = fieldValues[node.value['id']];
   }
@@ -85,6 +84,7 @@ export async function evaluateAsyncExpression(
   findAndRegisterReferencedFields(node, parts, fields);
   // setup function scope
   let { mode, myValue, patient } = context;
+  const { sex, age } = patient;
   if (node.type === 'field' && myValue === undefined) {
     myValue = fieldValues[node.value['id']];
   }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR attempts to provide `sex` and `age` to the evaluation context. This is to enable backward compatibility and achieve `schema` parity. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
