### PR TITLE
(fix) follow up PR to fix error brought by introducing `age` and `sex` in execution context

### DIFF
--- a/src/utils/expression-runner.ts
+++ b/src/utils/expression-runner.ts
@@ -29,7 +29,8 @@ export function evaluateExpression(
   findAndRegisterReferencedFields(node, parts, fields);
   // setup function scope
   let { mode, myValue, patient } = context;
-  const { sex, age } = patient;
+  const { sex, age } = patient && 'sex' in patient && 'age' in patient ? patient : { sex: undefined, age: undefined };
+
   if (node.type === 'field' && myValue === undefined) {
     myValue = fieldValues[node.value['id']];
   }
@@ -63,7 +64,7 @@ export function evaluateExpression(
   try {
     return eval(expression);
   } catch (error) {
-    console.error(error);
+    console.error(`Error: ${error} \n\n failing expression: ${expression}`);
   }
   return null;
 }
@@ -84,7 +85,7 @@ export async function evaluateAsyncExpression(
   findAndRegisterReferencedFields(node, parts, fields);
   // setup function scope
   let { mode, myValue, patient } = context;
-  const { sex, age } = patient;
+  const { sex, age } = patient && 'sex' in patient && 'age' in patient ? patient : { sex: undefined, age: undefined };
   if (node.type === 'field' && myValue === undefined) {
     myValue = fieldValues[node.value['id']];
   }
@@ -146,7 +147,7 @@ export async function evaluateAsyncExpression(
   try {
     return eval(expression);
   } catch (error) {
-    console.error(error);
+    console.error(`Error: ${error} \n\n failing expression: ${expression}`);
   }
   return null;
 }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This is a follow up PR to fix error where the expression runner was failing because in cases where we are evaluating the field validators the patient object isn't provided, since we are destructuring the patient object we run into an undefined error. This PR fixes that issue with `undefined` values. Secondly is to enhance the error handling by adding the failing expression to the dev-console

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
