### PR TITLE
(feat) Show error message from server when form submission fails

### DIFF
--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -218,7 +218,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
         })
         .catch(error => {
           showToast({
-            description: t('errorDescription', error.message),
+            description: t('errorDescription', error?.responseBody?.error?.message ?? error.message),
             title: t('errorDescriptionTitle', 'Error'),
             kind: 'error',
             critical: true,

--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -218,7 +218,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
         })
         .catch(error => {
           showToast({
-            description: t('errorDescription', error?.responseBody?.error?.message ?? error.message),
+            description: t('errorDescription', error?.responseBody?.error?.message ?? error?.message),
             title: t('errorDescriptionTitle', 'Error'),
             kind: 'error',
             critical: true,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Attempt to extract the exact error message from the server response if the encounter POST request fails when submitting a form. 