### PR TITLE
(fix) Fix previous value review UI

### DIFF
--- a/src/components/inputs/date/ohri-date.scss
+++ b/src/components/inputs/date/ohri-date.scss
@@ -1,7 +1,6 @@
 @use '@carbon/colors';
 
 .datetime > div {
-  margin-right: 02rem !important;
   flex: none !important;
   box-sizing: content-box !important;
 }

--- a/src/components/inputs/radio/ohri-radio.component.tsx
+++ b/src/components/inputs/radio/ohri-radio.component.tsx
@@ -68,51 +68,46 @@ const OHRIRadio: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }
   ) : (
     !question.isHidden && (
       <div className={styles.row}>
-        <div>
-          <FormGroup
-            style={{ paddingBottom: '1rem' }}
-            legendText={question.label}
-            className={isFieldRequiredError ? styles.errorLegend : undefined}
-            disabled={question.disabled}
-            invalid={!isFieldRequiredError && errors.length > 0}>
-            <RadioButtonGroup
-              defaultSelected="default-selected"
-              name={question.id}
-              valueSelected={field.value}
-              onChange={handleChange}
-              orientation="vertical">
-              {question.questionOptions.answers.map((answer, index) => {
-                return (
-                  <RadioButton
-                    id={`${question.id}-${answer.label}`}
-                    labelText={answer.label}
-                    value={answer.concept}
-                    key={index}
-                  />
-                );
-              })}
-            </RadioButtonGroup>
-            {(!isFieldRequiredError && errors?.length > 0) ||
-              (warnings.length > 0 && (
-                <div className={errors.length ? styles.errorLabel : warnings.length ? styles.warningLabel : ''}>
-                  <div className={`cds--form-requirement`}>
-                    {errors.length ? errors[0].message : warnings.length ? warnings[0].message : null}
-                  </div>
+        <FormGroup
+          legendText={question.label}
+          className={isFieldRequiredError ? styles.errorLegend : undefined}
+          disabled={question.disabled}
+          invalid={!isFieldRequiredError && errors.length > 0}>
+          <RadioButtonGroup
+            defaultSelected="default-selected"
+            name={question.id}
+            valueSelected={field.value}
+            onChange={handleChange}
+            orientation="vertical">
+            {question.questionOptions.answers.map((answer, index) => {
+              return (
+                <RadioButton
+                  id={`${question.id}-${answer.label}`}
+                  labelText={answer.label}
+                  value={answer.concept}
+                  key={index}
+                />
+              );
+            })}
+          </RadioButtonGroup>
+          {(!isFieldRequiredError && errors?.length > 0) ||
+            (warnings.length > 0 && (
+              <div className={errors.length ? styles.errorLabel : warnings.length ? styles.warningLabel : ''}>
+                <div className={`cds--form-requirement`}>
+                  {errors.length ? errors[0].message : warnings.length ? warnings[0].message : null}
                 </div>
-              ))}
+              </div>
+            ))}
+        </FormGroup>
+        {previousValueForReview ? (
+          <FormGroup legendText={null}>
+            <PreviousValueReview
+              value={previousValueForReview.value}
+              displayText={previousValueForReview.display}
+              setValue={handleChange}
+            />
           </FormGroup>
-        </div>
-        {previousValueForReview && (
-          <div>
-            <FormGroup legendText={null} className={styles.reviewPreviousValueRadioOverrides}>
-              <PreviousValueReview
-                value={previousValueForReview.value}
-                displayText={previousValueForReview.display}
-                setValue={handleChange}
-              />
-            </FormGroup>
-          </div>
-        )}
+        ) : null}
       </div>
     )
   );

--- a/src/components/inputs/radio/ohri-radio.scss
+++ b/src/components/inputs/radio/ohri-radio.scss
@@ -11,7 +11,7 @@
 .row {
   display: flex;
   flex-direction: row;
-  align-items: baseline;
+  align-items: center;
 }
 
 .errorLabel :global(.cds--form-requirement) {
@@ -32,10 +32,4 @@
   overflow: visible;
   font-weight: 400;
   color: colors.$gray-70;
-}
-
-.reviewPreviousValueRadioOverrides div {
-  width: auto !important;
-  position: absolute;
-  margin-top: -3.86rem;
 }

--- a/src/components/previous-value-review/previous-value-review.component.tsx
+++ b/src/components/previous-value-review/previous-value-review.component.tsx
@@ -12,27 +12,19 @@ export const PreviousValueReview: React.FC<{
 }> = ({ value, displayText, setValue, hideHeader }) => {
   const { t } = useTranslation();
   return (
-    <div className={styles.formField} style={{ marginLeft: '2rem', maxWidth: '19rem' }}>
-      {!hideHeader && (
-        <div>
-          <span className="cds--label">{t('previously', 'Previously')}</span>
-        </div>
-      )}
+    <div className={styles.formField}>
+      {!hideHeader && <span className="cds--label">{t('previousValue', 'Previous value')}</span>}
       <div className={styles.row}>
-        <div style={{ width: '100%' }}>
-          <OHRIValueDisplay value={displayText} />
-        </div>
-        <div style={{ width: '100%', marginLeft: '1rem' }}>
-          <Button
-            kind="ghost"
-            style={{ verticalAlign: 'baseline' }}
-            onClick={e => {
-              e.preventDefault();
-              setValue(value);
-            }}>
-            {t('useValue', 'Use value')}
-          </Button>
-        </div>
+        <OHRIValueDisplay value={displayText} />
+        <Button
+          className={styles.reuseButton}
+          kind="ghost"
+          onClick={e => {
+            e.preventDefault();
+            setValue(value);
+          }}>
+          {t('reuse', 'Reuse')}
+        </Button>
       </div>
     </div>
   );

--- a/src/components/previous-value-review/previous-value-review.scss
+++ b/src/components/previous-value-review/previous-value-review.scss
@@ -1,15 +1,20 @@
 @use '@carbon/colors';
 
 .formField {
-  margin-top: 10px;
-}
+  margin-left: 2rem; 
+  max-width: 19rem;
 
-.formField > div > div > label {
-  color: colors.$gray-70;
+  > div > div > label {
+    color: colors.$gray-70;
+  }
 }
 
 .row {
   display: flex;
   flex-direction: row;
   align-items: baseline;
+}
+
+.reuseButton {
+  margin-left: 3rem;
 }

--- a/src/components/value/ohri-value.component.tsx
+++ b/src/components/value/ohri-value.component.tsx
@@ -13,11 +13,7 @@ export const OHRIValueDisplay = ({ value }) => {
   if (Array.isArray(value)) {
     return <OHRIListDisplay valueArray={value} />;
   }
-  return (
-    <div>
-      <span className={styles.value}>{value}</span>
-    </div>
-  );
+  return <span className={styles.value}>{value}</span>;
 };
 
 const OHRIListDisplay = ({ valueArray }) => {

--- a/src/components/value/ohri-value.scss
+++ b/src/components/value/ohri-value.scss
@@ -2,6 +2,7 @@
 
 .value {
   font-size: 0.875rem;
+  font-weight: 600;
 }
 
 .empty {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the appearance of the previous value review UI after a regression following #68. Specifically, it tweaks the styling of the radio field, ensuring that both it and the review UI get enough breathing room. This PR also cleans up a bit of styling cruft and changes some of the wording of elements in the previous value UI.

## Screenshots

> Before

<img width="680" alt="Screenshot 2023-05-04 at 9 58 30 PM" src="https://user-images.githubusercontent.com/8509731/236303194-fe0e69e3-6f30-4818-8974-31737e43b563.png">

> After

<img width="680" alt="Screenshot 2023-05-04 at 9 56 08 PM" src="https://user-images.githubusercontent.com/8509731/236303217-92d1e2e9-7c06-4961-a0de-7375a5fc83cf.png">
