### PR TITLE
Fix highlight validation error messages for required field in number and multiselect controls

### DIFF
--- a/src/components/inputs/multi-select/ohri-multi-select.scss
+++ b/src/components/inputs/multi-select/ohri-multi-select.scss
@@ -22,11 +22,7 @@
   border-bottom: 1px solid #8d8d8d !important;
 }
 
-.errorLabel :global(.cds--form-requirement) {
-  display: block;
-  max-height: 12.5rem;
-  overflow: visible;
-  font-weight: 400;
+.errorLabel label {
   color: colors.$red-60;
 }
 

--- a/src/components/inputs/number/ohri-number.component.tsx
+++ b/src/components/inputs/number/ohri-number.component.tsx
@@ -102,6 +102,7 @@ const OHRINumber: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
             className={isFieldRequiredError ? styles.errorLabel : ''}
             warn={warnings.length > 0}
             warnText={warnings[0]?.message}
+            step="any"
           />
         </div>
         {previousValueForReview && (

--- a/src/components/inputs/number/ohri-number.component.tsx
+++ b/src/components/inputs/number/ohri-number.component.tsx
@@ -102,7 +102,7 @@ const OHRINumber: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
             className={isFieldRequiredError ? styles.errorLabel : ''}
             warn={warnings.length > 0}
             warnText={warnings[0]?.message}
-            step="any"
+            step="0.01"
           />
         </div>
         {previousValueForReview && (

--- a/src/components/inputs/number/ohri-number.scss
+++ b/src/components/inputs/number/ohri-number.scss
@@ -20,10 +20,6 @@
   align-items: baseline;
 }
 
-.errorLabel :global(.cds--form-requirement) {
-  display: block;
-  max-height: 12.5rem;
-  overflow: visible;
-  font-weight: 400;
+.errorLabel label {
   color: colors.$red-60;
 }


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Fixes a broken feature of highlighting the field's label when a field is **required** for number and multiselect controls. In addition to the above, this PR also includes an enhancement that adds support for decimal values to the number input control. Previously, only whole numbers were accepted, but now users can input decimal values as well.


## Screenshots
<!-- Required if you are making UI changes. -->
<img width="587" alt="Screenshot 2023-05-08 at 19 39 36" src="https://user-images.githubusercontent.com/26084581/236923327-c617eb32-4d8b-42c9-a859-b500d4c6d5ba.png">
<img width="451" alt="Screenshot 2023-05-08 at 23 07 20" src="https://user-images.githubusercontent.com/26084581/236923351-7ef6a396-dbd1-4cec-ab7f-b32fbc7848c6.png">

