### PR TITLE
(feat) Don't show an error toast when a patient UUID is not present

### DIFF
--- a/src/hooks/usePatientData.tsx
+++ b/src/hooks/usePatientData.tsx
@@ -14,19 +14,21 @@ function calculateAge(birthDate: Date): number {
   }
 }
 
-const patientGenderMap = {
-  female: 'F',
-  male: 'M',
-  other: 'O',
-  unknown: 'U',
-};
+export const usePatientData = (patientUuid: string) => {
+  const patientGenderMap = {
+    female: 'F',
+    male: 'M',
+    other: 'O',
+    unknown: 'U',
+  };
 
-export const usePatientData = patientUuid => {
   const { patient, isLoading: isLoadingPatient, error: patientError } = usePatient(patientUuid);
+
   if (patient && !isLoadingPatient) {
     // This is to support backward compatibility with the AMPATH JSON format
     patient['age'] = calculateAge(new Date(patient?.birthDate));
     patient['sex'] = patientGenderMap[patient.gender] ?? 'U';
   }
+
   return { patient, isLoadingPatient, patientError };
 };


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

When the user launches the form engine in a context where a patient UUID is not provided, an error toast gets displayed on the screen. An example is the form builder, where the form engine renders the provided schema in the form preview UI. Because we don't have a `patientUUID` in that context (compared to somewhere like the patient chart), the user gets shown a toast error message. Given that the utility of the patient UUID seems limited to just rendering a patient banner, it's best not to display the patient banner when a patient UUID is not present.

