### PR TITLE
fix usePreviousValueDisabled bug

### DIFF
--- a/src/components/encounter/ohri-encounter-form.component.tsx
+++ b/src/components/encounter/ohri-encounter-form.component.tsx
@@ -240,7 +240,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
   }, [tempInitialValues]);
 
   useEffect(() => {
-    if (sessionMode == 'enter' && !formJson.formOptions?.usePreviousValueDisabled) {
+    if (sessionMode == 'enter' && !isTrue(formJson.formOptions?.usePreviousValueDisabled)) {
       getPreviousEncounter(patient?.id, formJson?.encounterType).then(data => {
         setPreviousEncounter(data);
         setIsLoadingPreviousEncounter(false);

--- a/src/components/inputs/date/ohri-date.component.tsx
+++ b/src/components/inputs/date/ohri-date.component.tsx
@@ -96,7 +96,7 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
   }, []);
 
   useEffect(() => {
-    if (encounterContext?.previousEncounter && !question.questionOptions.usePreviousValueDisabled) {
+    if (encounterContext?.previousEncounter && !isTrue(question.questionOptions.usePreviousValueDisabled)) {
       let prevValue = handler?.getPreviousValue(question, encounterContext?.previousEncounter, fields);
 
       if (!isEmpty(prevValue?.value)) {

--- a/src/components/inputs/number/ohri-number.component.tsx
+++ b/src/components/inputs/number/ohri-number.component.tsx
@@ -49,7 +49,7 @@ const OHRINumber: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
   };
 
   useEffect(() => {
-    if (encounterContext?.previousEncounter && !question.questionOptions.usePreviousValueDisabled) {
+    if (encounterContext?.previousEncounter && !isTrue(question.questionOptions.usePreviousValueDisabled)) {
       const prevValue = handler?.getPreviousValue(question, encounterContext?.previousEncounter, fields);
       if (!isEmpty(prevValue?.value)) {
         setPreviousValueForReview(prevValue);

--- a/src/components/inputs/radio/ohri-radio.component.tsx
+++ b/src/components/inputs/radio/ohri-radio.component.tsx
@@ -40,7 +40,7 @@ const OHRIRadio: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }
   }, [conceptName]);
 
   useEffect(() => {
-    if (encounterContext?.previousEncounter && !question.questionOptions.usePreviousValueDisabled) {
+    if (encounterContext?.previousEncounter && !isTrue(question.questionOptions.usePreviousValueDisabled)) {
       const prevValue = handler?.getPreviousValue(question, encounterContext?.previousEncounter, fields);
       if (!isEmpty(prevValue?.value)) {
         setPreviousValueForReview(prevValue);

--- a/src/components/inputs/select/ohri-dropdown.component.tsx
+++ b/src/components/inputs/select/ohri-dropdown.component.tsx
@@ -50,7 +50,7 @@ const OHRIDropdown: React.FC<OHRIFormFieldProps> = ({ question, onChange, handle
   }, [conceptName]);
 
   useEffect(() => {
-    if (encounterContext?.previousEncounter && !question.questionOptions.usePreviousValueDisabled) {
+    if (encounterContext?.previousEncounter && !isTrue(question.questionOptions.usePreviousValueDisabled)) {
       const prevValue = handler?.getPreviousValue(question, encounterContext?.previousEncounter, fields);
       if (!isEmpty(prevValue?.value)) {
         setPreviousValueForReview(prevValue);

--- a/src/components/inputs/text/ohri-text.component.tsx
+++ b/src/components/inputs/text/ohri-text.component.tsx
@@ -29,7 +29,7 @@ const OHRIText: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
   }, [question['submission']]);
 
   useEffect(() => {
-    if (encounterContext?.previousEncounter && !question.questionOptions.usePreviousValueDisabled) {
+    if (encounterContext?.previousEncounter && !isTrue(question.questionOptions.usePreviousValueDisabled)) {
       const prevValue = handler?.getPreviousValue(question, encounterContext?.previousEncounter, fields);
       if (!isEmpty(prevValue?.value)) {
         setPreviousValueForReview(prevValue);


### PR DESCRIPTION
We introduced a feature to allow a user to select whether use of previous value should be enabled or not. This is both at field and form level using the usePreviousValueDisabled flag. However the moment the flag would be added, the use of previous value would be disabled irrespective of whether the flag is set to true or false.
This PR fixes that bug.
