### PR TITLE
(fix) Remove some global styles affecting the workspace

### DIFF
--- a/src/components/sidebar/ohri-form-sidebar.scss
+++ b/src/components/sidebar/ohri-form-sidebar.scss
@@ -4,7 +4,7 @@
   width: 12rem;
   min-height: 8rem;
   overscroll-behavior: contain;
-  margin: 1px 13px 15px 0;
+  margin-right: 1rem;
 }
 
 .sidebarList {
@@ -36,59 +36,51 @@
   letter-spacing: 0.16px;
   color: colors.$gray-100;
   cursor: pointer;
+
+  &:hover {
+    outline: none;
+  }
 }
 
-.link:hover {
-  outline: none;
-}
-
-// Sidebar-Section
 .sidebarSection {
   border-left: 0.5rem solid var(--brand-03);
-  height: auto;
-  margin: 0.122rem 0 0.122rem;
-  padding: 0.382rem 0.375rem 0.118rem 1rem;
-  background-color: white;
+  height: 2rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis; 
+  padding: 0.25rem 0.5rem;
+  background-color: colors.$white-0;
   cursor: pointer;
+
+  &:hover {
+    background-color: colors.$gray-10;
+  }
 }
 
 .sidebarSectionActive {
-  border-left: 0.5rem solid var(--brand-01);
-  height: auto;
+  @extend .sidebarSection;
   font-weight: 600;
-  margin: 0.122rem 0 0.122rem;
-  padding: 0.382rem 0.375rem 0.118rem 1rem;
-  background-color: #ededed;
-  cursor: pointer;
+  background-color: colors.$gray-20;
 }
 
 .sidebarSectionDone {
+  @extend .sidebarSection;
   border-left: 0.5rem solid var(--brand-02);
-  height: auto;
-  margin: 0.122rem 0 0.122rem;
-  padding: 0.382rem 0.375rem 0.118rem 1rem;
   background-color: colors.$green-10;
-  cursor: pointer;
 }
 
-.sidebarSectionError{
+.sidebarSectionError {
+  @extend .sidebarSection;
   border-left: 0.5rem solid colors.$red-60;
-  height: auto;
   color: colors.$red-70 !important;
-  margin: 0.122rem 0 0.122rem;
-  padding: 0.382rem 0.375rem 0.118rem 1rem;
   background-color: colors.$red-20;
-  cursor: pointer;
 }
-.sidebarSectionErrorActive{
+
+.sidebarSectionErrorActive {
   border-left: 0.5rem solid colors.$red-60;
-  height: auto;
   font-weight: 600;
   color: colors.$red-70 !important;
-  margin: 0.122rem 0 0.122rem;
-  padding: 0.382rem 0.375rem 0.118rem 1rem;
   background-color: colors.$red-20;
-  cursor: pointer;
 }
 
 .sidebarSectionLink {

--- a/src/ohri-form.scss
+++ b/src/ohri-form.scss
@@ -28,6 +28,7 @@
 }
 
 .formContent {
+  height: calc(100vh - 6rem);
   margin: 0;
   flex-basis: 65%;
   flex-grow: 1;
@@ -68,15 +69,3 @@
   padding: 1rem;
 }
 
-aside[class*='-esm-patient-chart__workspace-window__container__'] {
-  border-left: 1px solid #8d8d8d !important;
-}
-
-aside[class*='-esm-patient-chart__workspace-window__container__'] > div {
-  display: flex;
-  bottom: 0;
-}
-
-aside[class*='-esm-patient-chart__workspace-window__container__'] > div > div {
-  flex-grow: 1;
-}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Relates to [this conversation](https://openmrs.slack.com/archives/CHP5QAE5R/p1685109135001679) on Slack.

This PR removes some global styles from the form engine affecting the styling of the workspace window in the patient chart. It also applies some minor visual tweaks to the form engine, including:

- Tweaking the margin applied to the form pages on the sidebar on desktop
- Setting the form's height to the viewport's height so it spans the whole page.
- Setting the background colour of sidebar items on hover to `colors.$color-gray-10` (per this [design](https://zeroheight.com/23a080e38/p/9014c5-form-navigation)).
- Changing the background colour of the active form page in the sidebar to `colors.$color-gray-20` (per this [design](https://zeroheight.com/23a080e38/p/9014c5-form-navigation)).

## Video

https://github.com/openmrs/openmrs-form-engine-lib/assets/8509731/188ce18a-6353-4a20-bd1d-9a19a3971609



