### PR TITLE
(feat) O3-2004 Add support for rendering file type

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -163,6 +163,8 @@ export interface OHRIFormQuestionOptions {
   };
   isDateTime?: { labelTrue: boolean; labelFalse: boolean };
   usePreviousValueDisabled?: boolean;
+  allowedFileTypes?: Array<string>;
+  allowMultiple?: boolean;
 }
 
 export type SessionMode = 'edit' | 'enter' | 'view';
@@ -182,7 +184,8 @@ export type RenderType =
   | 'encounter-location'
   | 'textarea'
   | 'toggle'
-  | 'fixed-value';
+  | 'fixed-value'
+  | 'file';
 
 export interface PostSubmissionAction {
   applyAction(formSession: {

--- a/src/components/inputs/file/file.component.tsx
+++ b/src/components/inputs/file/file.component.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { FileUploader } from '@carbon/react';
+import { useTranslation } from 'react-i18next';
+import { OHRIFormFieldProps } from '../../../api/types';
+import { useField } from 'formik';
+import { OHRIFormContext } from '../../../ohri-form-context';
+
+interface FileProps extends OHRIFormFieldProps {}
+
+const File: React.FC<FileProps> = ({ question, onChange, handler }) => {
+  const { t } = useTranslation();
+  const [field, meta] = useField(question.id);
+  const { setFieldValue } = React.useContext(OHRIFormContext);
+
+  const labelDescription = question.questionOptions.allowedFileTypes
+    ? t('fileUploadDescription', `Upload one of the following file types: ${question.questionOptions.allowedFileTypes}`)
+    : t('fileUploadDescriptionAny', 'Upload any file type');
+
+  return (
+    <FileUploader
+      {...field}
+      accept={question.questionOptions.allowedFileTypes ?? []}
+      buttonKind="primary"
+      buttonLabel={t('addFile', 'Add files')}
+      filenameStatus="edit"
+      iconDescription="Clear file"
+      labelDescription={labelDescription}
+      labelTitle={t('fileUploadTitle', 'Upload')}
+      multiple={question.questionOptions.allowMultiple}
+      onChange={event => setFieldValue(question.id, event.target.files[0])}
+    />
+  );
+};
+
+export default File;

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -21,6 +21,7 @@ import { getGlobalStore } from '@openmrs/esm-framework';
 import { OHRIFormsStore } from '../constants';
 import OHRIExtensionParcel from '../components/extension/ohri-extension-parcel.component';
 import { EncounterDatetimeHandler } from '../submission-handlers/encounterDatetimeHandler';
+import File from '../components/inputs/file/file.component';
 
 export interface RegistryItem {
   id: string;
@@ -146,6 +147,12 @@ export const baseFieldComponents: Array<CustomControlRegistration> = [
     id: 'OHRIDateTime',
     loadControl: () => Promise.resolve({ default: OHRIDate }),
     type: 'datetime',
+    alias: '',
+  },
+  {
+    id: 'file',
+    loadControl: () => Promise.resolve({ default: File }),
+    type: 'file',
     alias: '',
   },
 ];


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR add supports for rendering and uploading files, which is supported as complex obs with the form engine. I have broken the work into small sub-task as follows
- [x] Addition of a file component and schema update to include the required questionOption for rendering files, including specifications such as maximum allowed file size and allowed file types (e.g., .jpg).
- [ ] Implementation of a preview feature for files that are yet to be uploaded.
- [ ] Introduction of the ability to view uploaded files when the form is opened in both "view" and "edit" modes.
- [ ] Inclusion of functionality to delete uploaded files.
- [ ] Integration of form handlers to manage file uploading and deletion.

## Screenshots

![Kapture 2023-05-29 at 23 51 22](https://github.com/openmrs/openmrs-form-engine-lib/assets/28008754/54ac04ef-e30c-4b92-9eb1-0fce83e33098)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
