### PR TITLE
(feat) O3-2212: hide the form navigation menu for single page forms

### DIFF
--- a/src/components/sidebar/ohri-form-sidebar.component.tsx
+++ b/src/components/sidebar/ohri-form-sidebar.component.tsx
@@ -63,30 +63,38 @@ function OHRIFormSidebar({
     },
     [unspecifiedFields],
   );
+
+  // Check if there is only one scrollable page
+  const isSinglePage = scrollablePages.length === 1;
+
   return (
     <div className={styles.sidebar}>
-      {[...scrollablePages].map((page, index) => {
-        return (
-          !page.isHidden && (
-            <div
-              aria-hidden="true"
-              className={
-                joinWord(page.label) === selectedPage && pagesWithErrors.includes(page.label)
-                  ? styles.sidebarSectionErrorActive
-                  : joinWord(page.label) === selectedPage
-                  ? styles.sidebarSectionActive
-                  : pagesWithErrors.includes(page.label)
-                  ? styles.sidebarSectionError
-                  : styles.sidebarSection
-              }
-              key={index}
-              onClick={() => handleClick(page.label)}>
-              <div className={styles.sidebarSectionLink}>{page.label}</div>
-            </div>
-          )
-        );
-      })}
-      {mode !== 'view' && <hr className={styles.sideBarHorizontalLine} />}
+      {!isSinglePage && (
+        <>
+          {[...scrollablePages].map((page, index) => {
+            return (
+              !page.isHidden && (
+                <div
+                  aria-hidden="true"
+                  className={
+                    joinWord(page.label) === selectedPage && pagesWithErrors.includes(page.label)
+                      ? styles.sidebarSectionErrorActive
+                      : joinWord(page.label) === selectedPage
+                      ? styles.sidebarSectionActive
+                      : pagesWithErrors.includes(page.label)
+                      ? styles.sidebarSectionError
+                      : styles.sidebarSection
+                  }
+                  key={index}
+                  onClick={() => handleClick(page.label)}>
+                  <div className={styles.sidebarSectionLink}>{page.label}</div>
+                </div>
+              )
+            );
+          })}
+          <hr className={styles.sideBarHorizontalLine} />
+        </>
+      )}
       <div className={styles.sidenavActions}>
         {allowUnspecifiedAll && mode !== 'view' && (
           <div style={{ marginBottom: '.6rem' }}>
@@ -99,7 +107,7 @@ function OHRIFormSidebar({
             />
           </div>
         )}
-        {mode != 'view' && (
+        {mode !== 'view' && (
           <Button style={{ marginBottom: '0.625rem', width: '11rem' }} type="submit" disabled={isFormSubmitting}>
             Save
           </Button>
@@ -111,7 +119,7 @@ function OHRIFormSidebar({
             onCancel && onCancel();
             handleClose && handleClose();
           }}>
-          {mode == 'view' ? 'Close' : 'Cancel'}
+          {mode === 'view' ? 'Close' : 'Cancel'}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Add ability to hide form navigation if the form has only one page


## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-2212

## Other
<!-- Anything not covered above -->
