### PR TITLE
O3 2168 Form Engine: Handle case when # of concepts on a form exceeds REST page length

### DIFF
--- a/src/hooks/useConcepts.tsx
+++ b/src/hooks/useConcepts.tsx
@@ -30,5 +30,6 @@ export function useConcepts(references: Set<string>) {
     `/ws/rest/v1/concept?references=${Array.from(references).join(',')}&v=${conceptRepresentation}`,
     openmrsFetch,
   );
+  
   return { concepts: data?.data.results, error, isLoading };
   }

--- a/src/hooks/useConcepts.tsx
+++ b/src/hooks/useConcepts.tsx
@@ -5,10 +5,30 @@ const conceptRepresentation =
   'custom:(uuid,display,conceptMappings:(conceptReferenceTerm:(conceptSource:(name),code)))';
 
 export function useConcepts(references: Set<string>) {
+  const pageSize = 50;
+
+  const fetchConcepts = async (url:String) => {
+    const response = await openmrsFetch(url);
+    const totalCount = response.headers.get('X-Total-Count');
+    const totalPages = Math.ceil(Number(totalCount)/pageSize);
+
+    const results: OpenmrsResource[] = await response.json();
+    let fetchedResults = results;
+
+    for (let page = 2; page <= totalPages; page++) {
+      const nextPageUrl = `${url}&startIndex=${(page - 1) * pageSize}&v=${conceptRepresentation}`;
+      const nextPageResponse = await openmrsFetch(nextPageUrl);
+      const nextPageResults: OpenmrsResource[] = await nextPageResponse.json();
+      fetchedResults = fetchedResults.concat(nextPageResults);
+    }
+
+    return { results: fetchedResults };
+  };
+  
   // TODO: handle paging (ie when number of concepts greater than default limit per page)
   const { data, error, isLoading } = useSWRImmutable<{ data: { results: Array<OpenmrsResource> } }, Error>(
     `/ws/rest/v1/concept?references=${Array.from(references).join(',')}&v=${conceptRepresentation}`,
     openmrsFetch,
   );
   return { concepts: data?.data.results, error, isLoading };
-}
+  }

--- a/src/hooks/useConcepts.tsx
+++ b/src/hooks/useConcepts.tsx
@@ -6,6 +6,11 @@ const conceptRepresentation =
 
 export function useConcepts(references: Set<string>) {
   const pageSize = 50;
+   // TODO: handle paging (ie when number of concepts greater than default limit per page)
+   const { data, error, isLoading } = useSWRImmutable<{ data: { results: Array<OpenmrsResource> } }, Error>(
+    `/ws/rest/v1/concept?references=${Array.from(references).join(',')}&v=${conceptRepresentation}`,
+    openmrsFetch,
+  );
 
   const fetchConcepts = async (url:string) => {
     const response = await openmrsFetch(url);
@@ -25,11 +30,6 @@ export function useConcepts(references: Set<string>) {
     return { results: fetchedResults };
   };
   
-  // TODO: handle paging (ie when number of concepts greater than default limit per page)
-  const { data, error, isLoading } = useSWRImmutable<{ data: { results: Array<OpenmrsResource> } }, Error>(
-    `/ws/rest/v1/concept?references=${Array.from(references).join(',')}&v=${conceptRepresentation}`,
-    openmrsFetch,
-  );
-
+ 
   return { concepts: data?.data.results, error, isLoading };
   }

--- a/src/hooks/useConcepts.tsx
+++ b/src/hooks/useConcepts.tsx
@@ -7,7 +7,7 @@ const conceptRepresentation =
 export function useConcepts(references: Set<string>) {
   const pageSize = 50;
 
-  const fetchConcepts = async (url:String) => {
+  const fetchConcepts = async (url:string) => {
     const response = await openmrsFetch(url);
     const totalCount = response.headers.get('X-Total-Count');
     const totalPages = Math.ceil(Number(totalCount)/pageSize);
@@ -30,6 +30,6 @@ export function useConcepts(references: Set<string>) {
     `/ws/rest/v1/concept?references=${Array.from(references).join(',')}&v=${conceptRepresentation}`,
     openmrsFetch,
   );
-  
+
   return { concepts: data?.data.results, error, isLoading };
   }

--- a/src/hooks/useConcepts.tsx
+++ b/src/hooks/useConcepts.tsx
@@ -20,16 +20,20 @@ export function useConcepts(references: Set<string>) {
     const results: OpenmrsResource[] = await response.json();
     let fetchedResults = results;
 
+    const fetchPromises: Promise<OpenmrsResource[]>[] = [];
     for (let page = 2; page <= totalPages; page++) {
       const nextPageUrl = `${url}&startIndex=${(page - 1) * pageSize}&v=${conceptRepresentation}`;
-      const nextPageResponse = await openmrsFetch(nextPageUrl);
-      const nextPageResults: OpenmrsResource[] = await nextPageResponse.json();
-      fetchedResults = fetchedResults.concat(nextPageResults);
+      fetchPromises.push(openmrsFetch(nextPageUrl).then((res) => res.json()));
     }
+     const remainingResults = await Promise.all(fetchPromises);
+    remainingResults.forEach((pageResults) => {
+      fetchedResults = fetchedResults.concat(pageResults);
+    });
 
     return { results: fetchedResults };
   };
   
- 
   return { concepts: data?.data.results, error, isLoading };
-  }
+}
+
+


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.
## Description of what I changed
Enhanced the concept fetching process for form references to ensure accurate retrieval of all concepts. Addressed issues related to REST API pagination that were causing missed concepts. Implemented a more precise fetching logic that aligns with the API's pagination mechanism.
## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://issues.openmrs.org/browse/O3-2168
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
