### PR TITLE
The addDaysToDate function should not modify the original date.

### DIFF
--- a/src/utils/common-expression-helpers.ts
+++ b/src/utils/common-expression-helpers.ts
@@ -80,10 +80,9 @@ export class CommonExpressionHelpers {
 
   addDaysToDate = (date, days) => {
     const newDate = new Date(date);
-    dayjs(newDate).format('DD/MM/YYYY')
     newDate.setDate(newDate.getDate() + days); 
     if(isNaN(newDate.getTime())){
-      return;
+      return null;
     }
     return newDate;
   };

--- a/src/utils/common-expression-helpers.ts
+++ b/src/utils/common-expression-helpers.ts
@@ -78,13 +78,10 @@ export class CommonExpressionHelpers {
     return date;
   };
 
-  addDaysToDate = (date, days) => {
-    const newDate = new Date(date);
-    newDate.setDate(newDate.getDate() + days); 
-    if(isNaN(newDate.getTime())){
-      return null;
-    }
-    return newDate;
+  addDaysToDate = (date: Date, days: number): Date => {
+    return dayjs(date)
+      .add(days, 'day')
+      .toDate();
   };
 
   useFieldValue = (questionId: string) => {

--- a/src/utils/common-expression-helpers.ts
+++ b/src/utils/common-expression-helpers.ts
@@ -79,9 +79,17 @@ export class CommonExpressionHelpers {
   };
 
   addDaysToDate = (date, days) => {
-    date.setDate(date.getDate() + days);
+    const newDate = new Date(date);
+    dayjs(newDate).format('DD/MM/YYYY')
+    newDate.setDate(newDate.getDate() + days); 
+    if(isNaN(newDate.getTime())){
+      return;
+    }
+    return newDate;
 
-    return date;
+    // date.setDate(date.getDate() + days);
+
+    // return date;
   };
 
   useFieldValue = (questionId: string) => {

--- a/src/utils/common-expression-helpers.ts
+++ b/src/utils/common-expression-helpers.ts
@@ -86,10 +86,6 @@ export class CommonExpressionHelpers {
       return;
     }
     return newDate;
-
-    // date.setDate(date.getDate() + days);
-
-    // return date;
   };
 
   useFieldValue = (questionId: string) => {


### PR DESCRIPTION
The problem with the function was that it directly modified the original date object using the setDate method. As a result, it caused unexpected behavior where the modification affected the original object. This led to the visit date and the next visit date being the same after adding a certain number of days to the visit date, as shown in the screenshot bellow:

<img width="802" alt="Screenshot 2023-07-08 at 8 35 23 AM" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/19629227/76539ea2-d6d7-4978-93a6-232d73eb845c">

To fix this issue, I created a new Date object based on the original date and perform the calculations on the new object.

<img width="810" alt="Screenshot 2023-07-08 at 8 32 29 AM" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/19629227/9a6e2681-1004-461d-87b4-449afba17fa6">


Additionally, I included a check to verify if the resulting date is valid by checking if newDate.getTime() returns NaN. If the date is invalid, the function returns undefined and this was being displayed on the form.