### PR TITLE
fix/ O3-2253:Marking a field as readonly should render the field control as opposed to switching to view mode

### DIFF
--- a/src/components/inputs/date/ohri-date.component.tsx
+++ b/src/components/inputs/date/ohri-date.component.tsx
@@ -132,7 +132,7 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
     }
   }, [field.value, time]);
 
-  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
+  return encounterContext.sessionMode == 'view' ? (
     <OHRIFieldValueView
       label={question.label}
       value={field.value instanceof Date ? getDisplay(field.value, question.questionOptions.rendering) : field.value}
@@ -170,6 +170,7 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
                 invalidText={errors[0]?.message}
                 warn={warnings.length > 0}
                 warnText={warnings[0]?.message}
+                readOnly={question.readonly}
               />
             </DatePicker>
           </div>

--- a/src/components/inputs/location/ohri-encounter-location.component.tsx
+++ b/src/components/inputs/location/ohri-encounter-location.component.tsx
@@ -36,7 +36,7 @@ export const OHRIEncounterLocationPicker: React.FC<{ question: OHRIFormField; on
     });
   }, [conceptName]);
 
-  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
+  return encounterContext.sessionMode == 'view' ? (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}
@@ -59,6 +59,7 @@ export const OHRIEncounterLocationPicker: React.FC<{ question: OHRIFormField; on
             setFieldValue(question.id, selectedItem);
             setEncounterLocation(selectedItem);
           }}
+          readOnly={question.readonly}
           disabled={question.disabled}
         />
       </div>

--- a/src/components/inputs/multi-select/ohri-multi-select.component.tsx
+++ b/src/components/inputs/multi-select/ohri-multi-select.component.tsx
@@ -78,7 +78,7 @@ export const OHRIMultiSelect: React.FC<OHRIFormFieldProps> = ({ question, onChan
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
+  return encounterContext.sessionMode == 'view' ? (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}
@@ -111,6 +111,7 @@ export const OHRIMultiSelect: React.FC<OHRIFormFieldProps> = ({ question, onChan
             invalidText={errors[0]?.message}
             warn={warnings.length > 0}
             warnText={warnings[0]?.message}
+            readOnly={question.readonly}
           />
         </div>
         <div className={styles.formField} style={{ marginTop: '0.125rem' }}>

--- a/src/components/inputs/number/ohri-number.component.tsx
+++ b/src/components/inputs/number/ohri-number.component.tsx
@@ -70,7 +70,7 @@ const OHRINumber: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
+  return encounterContext.sessionMode == 'view' ? (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}
@@ -99,6 +99,7 @@ const OHRINumber: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
             hideSteppers={true}
             onWheel={e => e.target.blur()}
             disabled={question.disabled}
+            readOnly={question.readonly}
             className={isFieldRequiredError ? styles.errorLabel : ''}
             warn={warnings.length > 0}
             warnText={warnings[0]?.message}

--- a/src/components/inputs/radio/ohri-radio.component.tsx
+++ b/src/components/inputs/radio/ohri-radio.component.tsx
@@ -56,7 +56,7 @@ const OHRIRadio: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
+  return encounterContext.sessionMode == 'view' ? (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}
@@ -78,6 +78,7 @@ const OHRIRadio: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }
             name={question.id}
             valueSelected={field.value}
             onChange={handleChange}
+            readOnly={question.readonly}
             orientation="vertical">
             {question.questionOptions.answers
               .filter(answer => !answer.isHidden)

--- a/src/components/inputs/radio/ohri-radio.component.tsx
+++ b/src/components/inputs/radio/ohri-radio.component.tsx
@@ -56,7 +56,7 @@ const OHRIRadio: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' ? (
+  return encounterContext.sessionMode == 'view' ? || isTrue(question.readonly) (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}
@@ -78,7 +78,6 @@ const OHRIRadio: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }
             name={question.id}
             valueSelected={field.value}
             onChange={handleChange}
-            readOnly={question.readonly}
             orientation="vertical">
             {question.questionOptions.answers
               .filter(answer => !answer.isHidden)

--- a/src/components/inputs/radio/ohri-radio.component.tsx
+++ b/src/components/inputs/radio/ohri-radio.component.tsx
@@ -56,7 +56,7 @@ const OHRIRadio: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' ? || isTrue(question.readonly) (
+  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}

--- a/src/components/inputs/select/ohri-dropdown.component.tsx
+++ b/src/components/inputs/select/ohri-dropdown.component.tsx
@@ -65,7 +65,7 @@ const OHRIDropdown: React.FC<OHRIFormFieldProps> = ({ question, onChange, handle
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
+  return encounterContext.sessionMode == 'view' ? (
     <OHRIFieldValueView
       label={question.label}
       value={field.value ? handler?.getDisplayValue(question, field.value) : field.value}
@@ -87,6 +87,7 @@ const OHRIDropdown: React.FC<OHRIFormFieldProps> = ({ question, onChange, handle
             selectedItem={field.value}
             onChange={({ selectedItem }) => handleChange(selectedItem)}
             disabled={question.disabled}
+            readOnly={question.readonly}
             invalid={!isFieldRequiredError && errors.length > 0}
             invalidText={errors.length && errors[0].message}
             warn={warnings.length > 0}

--- a/src/components/inputs/text-area/ohri-text-area.component.tsx
+++ b/src/components/inputs/text-area/ohri-text-area.component.tsx
@@ -48,7 +48,7 @@ const OHRITextArea: React.FC<OHRIFormFieldProps> = ({ question, onChange, handle
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
+  return encounterContext.sessionMode == 'view' ? (
     <div className={styles.formField}>
       <OHRIFieldValueView label={question.label} value={field.value} conceptName={conceptName} isInline={isInline} />
     </div>
@@ -68,6 +68,7 @@ const OHRITextArea: React.FC<OHRIFormFieldProps> = ({ question, onChange, handle
             onFocus={() => setPreviousValue(field.value)}
             rows={question.questionOptions.rows || 4}
             disabled={question.disabled}
+            readOnly={question.readonly}
             invalid={!isFieldRequiredError && errors.length > 0}
             invalidText={errors.length && errors[0].message}
             warn={warnings.length > 0}

--- a/src/components/inputs/text/ohri-text.component.tsx
+++ b/src/components/inputs/text/ohri-text.component.tsx
@@ -66,7 +66,7 @@ const OHRIText: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
+  return encounterContext.sessionMode == 'view' ? (
     <div className={styles.formField}>
       <OHRIFieldValueView label={question.label} value={field.value} conceptName={conceptName} isInline={isInline} />
     </div>
@@ -86,6 +86,7 @@ const OHRIText: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
               value={field.value || ''}
               onFocus={() => setPreviousValue(field.value)}
               disabled={question.disabled}
+              readOnly={question.readonly}
               invalid={!isFieldRequiredError && errors.length > 0}
               invalidText={errors.length && errors[0].message}
               warn={warnings.length > 0}

--- a/src/components/inputs/toggle/ohri-toggle.component.tsx
+++ b/src/components/inputs/toggle/ohri-toggle.component.tsx
@@ -40,7 +40,7 @@ const OHRIToggle: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
+  return encounterContext.sessionMode == 'view' ? (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}
@@ -60,6 +60,7 @@ const OHRIToggle: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
           onToggle={handleChange}
           toggled={!!field.value}
           disabled={question.disabled}
+          readOnly={question.readonly}
         />
       </div>
     )

--- a/src/components/inputs/ui-select-extended/ui-select-extended.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.tsx
@@ -90,7 +90,7 @@ export const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handl
     }
     return changes;
   };
-  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
+  return encounterContext.sessionMode == 'view' ? (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}
@@ -130,6 +130,7 @@ export const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handl
               }}
               onChange={({ selectedItem }) => handleChange(selectedItem?.uuid)}
               disabled={question.disabled}
+              readOnly={question.readonly}
               onInputChange={value => {
                 inputValue.current = value;
                 if (question.questionOptions['isSearchable']) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
In "edit" and "enter" mode, the fields marked as read-only should render the controlled in readOnly mode and not the default view mode display

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1440" alt="Screenshot 2023-08-23 at 15 50 40" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/51090527/15ae33fd-77c0-4839-ae8a-4430301d77ce">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
Link to community ticket: https://issues.openmrs.org/browse/O3-2303

## Other
<!-- Anything not covered above -->
