### PR TITLE
Fix 'useField' being undefined for customly registered controls within obs groups.

### DIFF
--- a/src/components/group/ohri-obs-group.component.tsx
+++ b/src/components/group/ohri-obs-group.component.tsx
@@ -5,6 +5,7 @@ import { OHRIFormFieldProps } from '../../api/types';
 import { OHRIUnspecified } from '../inputs/unspecified/ohri-unspecified.component';
 import { getFieldControl, supportsUnspecified } from '../section/ohri-form-section.component';
 import styles from './ohri-obs-group.scss';
+import { useField } from 'formik';
 
 export interface ObsGroupProps extends OHRIFormFieldProps {
   deleteControl?: any;
@@ -35,6 +36,7 @@ export const OHRIObsGroup: React.FC<ObsGroupProps> = ({ question, onChange, dele
           onChange: onChange,
           key: index,
           handler: getHandler(field.type),
+          useField,
         });
         return (
           <div className={`${styles.flexColumn} ${styles.obsGroupColumn} `}>


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Fix 'useField' being undefined for customly registered controls within obs groups.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
