### PR TITLE
(fix) Import TFunction annotation from i18next

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "jest-environment-jsdom": "^29.5.0",
     "jest-when": "^3.5.2",
     "openmrs": "next",
-    "prettier": "^3.0.0",
+    "prettier": "^2.6.0",
     "pretty-quick": "^1.11.1",
     "react": "^18.2.0",
     "react-i18next": "^11.18.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "jest-environment-jsdom": "^29.5.0",
     "jest-when": "^3.5.2",
     "openmrs": "next",
-    "prettier": "^1.18.2",
+    "prettier": "^3.0.0",
     "pretty-quick": "^1.11.1",
     "react": "^18.2.0",
     "react-i18next": "^11.18.1",

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -1,5 +1,5 @@
 import { showToast } from '@openmrs/esm-framework';
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 export function reportError(error: Error, t: TFunction): void {
   if (error) {

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -1,7 +1,7 @@
 import { showToast } from '@openmrs/esm-framework';
-import { TFunction } from 'react-i18next';
+import { TFunction } from 'i18next';
 
-export function reportError(error: Error, t: TFunction<'translation', undefined>): void {
+export function reportError(error: Error, t: TFunction): void {
   if (error) {
     console.error(error);
     showToast({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2788,7 +2788,7 @@ __metadata:
     jest-when: ^3.5.2
     lodash-es: ^4.17.15
     openmrs: next
-    prettier: ^1.18.2
+    prettier: ^3.0.0
     pretty-quick: ^1.11.1
     react: ^18.2.0
     react-anchor-link-smooth-scroll: ^1.0.12
@@ -13272,12 +13272,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^1.18.2":
-  version: 1.19.1
-  resolution: "prettier@npm:1.19.1"
+"prettier@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "prettier@npm:3.0.3"
   bin:
-    prettier: ./bin-prettier.js
-  checksum: bc78219e0f8173a808f4c6c8e0a137dd8ebd4fbe013e63fe1a37a82b48612f17b8ae8e18a992adf802ee2cf7428f14f084e7c2846ca5759cf4013c6e54810e1f
+    prettier: bin/prettier.cjs
+  checksum: e10b9af02b281f6c617362ebd2571b1d7fc9fb8a3bd17e371754428cda992e5e8d8b7a046e8f7d3e2da1dcd21aa001e2e3c797402ebb6111b5cd19609dd228e0
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2788,7 +2788,7 @@ __metadata:
     jest-when: ^3.5.2
     lodash-es: ^4.17.15
     openmrs: next
-    prettier: ^3.0.0
+    prettier: ^2.6.0
     pretty-quick: ^1.11.1
     react: ^18.2.0
     react-anchor-link-smooth-scroll: ^1.0.12
@@ -13272,12 +13272,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.0.0":
-  version: 3.0.3
-  resolution: "prettier@npm:3.0.3"
+"prettier@npm:^2.6.0":
+  version: 2.8.8
+  resolution: "prettier@npm:2.8.8"
   bin:
-    prettier: bin/prettier.cjs
-  checksum: e10b9af02b281f6c617362ebd2571b1d7fc9fb8a3bd17e371754428cda992e5e8d8b7a046e8f7d3e2da1dcd21aa001e2e3c797402ebb6111b5cd19609dd228e0
+    prettier: bin-prettier.js
+  checksum: b49e409431bf129dd89238d64299ba80717b57ff5a6d1c1a8b1a28b590d998a34e083fa13573bc732bb8d2305becb4c9a4407f8486c81fa7d55100eb08263cf8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR changes the source of the `TFunction` type annotation for the i18next `t` function from 'react-i18next' to `i18next`. This is to fix an upstream issue in the Form Builder where upgrading react-i18next leads to a type error because the TFunction annotation cannot be found. Switching to importing the annotation from i18next [aligns](https://github.com/i18next/react-i18next/blob/1ff5cabcebcc833af8410dc4c69ea08070dda745/index.d.ts#L9) things nicely with the library. 

> Screengrab of the error from the form builder

<img width="792" alt="CleanShot 2023-09-15 at 2 42 17@2x" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/8509731/5dd4b651-30e3-4645-b2cb-171a5de3348f">
