### PR TITLE
OHRI-1819: Child(s) PTracker ID in L&D form Validated or autopulated …

### DIFF
--- a/src/utils/common-expression-helpers.ts
+++ b/src/utils/common-expression-helpers.ts
@@ -280,6 +280,17 @@ export class CommonExpressionHelpers {
     return daySinceLastObs === '' ? '0' : daySinceLastObs;
   };
 
+  generateInfantPTrackerId = (fieldId: string, motherPtrackerId: string): string | undefined => {
+    if (!fieldId || !motherPtrackerId) return;
+  
+    return fieldId === 'infantPtrackerid'
+      ? motherPtrackerId + '1'
+      : fieldId.includes('_')
+      ? motherPtrackerId.concat(fieldId.split('_')[1])
+      : undefined;
+  };
+  
+
   /**
    * Used as wrapper around async functions. It basically evaluates the promised value.
    */


### PR DESCRIPTION
…based on the birth count form engine helper function

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR add support to auto populate the PTRacker ID for the Child in full based on the birth count and the mother’s ID i.e. the system should assign PTracker ID to the babies for baby number 1 mothers' ID and 1 for child 1 and 2 for child 2 and add three for child 3 etc

## Screenshots

https://github.com/openmrs/openmrs-form-engine-lib/assets/19629227/17dff732-14f9-4465-b1c8-1b15bd0bda3a



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
