### PR TITLE
(fix) Cannot read properties of undefined obs when opening edit /view mode of a form

### DIFF
--- a/src/components/encounter/ohri-encounter-form.component.tsx
+++ b/src/components/encounter/ohri-encounter-form.component.tsx
@@ -154,7 +154,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
     flattenedFields,
     encounter,
     encounterContext,
-    formFieldHandlers || {},
+    formFieldHandlers,
   );
 
   // look up concepts via their references

--- a/src/components/encounter/ohri-encounter-form.component.tsx
+++ b/src/components/encounter/ohri-encounter-form.component.tsx
@@ -154,7 +154,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
     flattenedFields,
     encounter,
     encounterContext,
-    formFieldHandlers,
+    formFieldHandlers || {},
   );
 
   // look up concepts via their references

--- a/src/hooks/useFormFieldHandlers.tsx
+++ b/src/hooks/useFormFieldHandlers.tsx
@@ -3,7 +3,7 @@ import { OHRIFormField, SubmissionHandler } from '../api/types';
 import { getRegisteredFieldSubmissionHandler } from '..';
 
 export function useFormFieldHandlers(fields: OHRIFormField[]) {
-  const [formFieldHandlers, setFormFieldHandlers] = useState<Record<string, SubmissionHandler>>();
+  const [formFieldHandlers, setFormFieldHandlers] = useState<Record<string, SubmissionHandler>>({});
 
   useEffect(() => {
     const supportedTypes = new Set<string>();

--- a/src/hooks/useInitialValues.ts
+++ b/src/hooks/useInitialValues.ts
@@ -41,7 +41,7 @@ export function useInitialValues(
     } else if (asyncInitValues) {
       setHasResolvedCalculatedValues(true);
     }
-  }, [asyncInitValues]);
+  }, [asyncInitValues, formFieldHandlers]);
 
   useEffect(() => {
     const repeatableFields = [];
@@ -50,6 +50,9 @@ export function useInitialValues(
       toggle: false,
       default: '',
     };
+    if (!Object.keys(formFieldHandlers).length) {
+      return;
+    }
     if (encounter) {
       formFields
         .filter(field => isEmpty(field.value))
@@ -132,7 +135,7 @@ export function useInitialValues(
       setAsyncInitValues({ ...(asyncInitValues ?? {}), ...tempAsyncValues });
     }
     setInitialValues({ ...initialValues });
-  }, [encounter]);
+  }, [encounter, formFieldHandlers]);
 
   return {
     initialValues,


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The FormFieldHandlers resolves all available handlers but was returning as undefined causing an error when opening a form view or edit action. Solution was to create a guard clause within the useEffect hook to check if is falsy and return an object thus preventing potential errors when trying to access properties of null or undefined.

## Screenshots
![image](https://github.com/openmrs/openmrs-form-engine-lib/assets/43242517/4bc822f5-f435-421d-bdb0-0bd8260c85a4)
## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
