### PR TITLE
(fix) Allowing confirmation modal to close form / preventing pop up in view mode

### DIFF
--- a/src/components/warning-modal.component.tsx
+++ b/src/components/warning-modal.component.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { Button, ComposedModal, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 
 type Props = {
-  onClose: () => void;
+  onCancel: () => void;
   onShowWarningModal: (showWarningModal: boolean) => void;
   t: (key: string, fallback: string) => string;
 };
 
-const WarningModal: React.FC<Props> = ({ onClose, onShowWarningModal, t }) => {
+const WarningModal: React.FC<Props> = ({ onCancel, onShowWarningModal, t }) => {
   return (
     <ComposedModal preventCloseOnClickOutside open={true} onClose={() => onShowWarningModal(false)}>
       <ModalHeader title={t('discardChanges', 'Discard changes?')}></ModalHeader>
@@ -23,7 +23,12 @@ const WarningModal: React.FC<Props> = ({ onClose, onShowWarningModal, t }) => {
         <Button kind="secondary" onClick={() => onShowWarningModal(false)}>
           {t('cancel', 'Cancel')}
         </Button>
-        <Button kind="danger" onClick={onClose}>
+        <Button
+          kind="danger"
+          onClick={() => {
+            onShowWarningModal(false);
+            onCancel && onCancel();
+          }}>
           {t('confirm', 'Confirm')}
         </Button>
       </ModalFooter>

--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -92,12 +92,11 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
   const currentProvider = session?.currentProvider?.uuid ? session.currentProvider.uuid : null;
   const location = session && !(encounterUUID || encounterUuid) ? session?.sessionLocation : null;
   const { patient, isLoadingPatient: isLoadingPatient, patientError: patientError } = usePatientData(patientUUID);
-  const { formJson: refinedFormJson, isLoading: isLoadingFormJson, formError } = useFormJson(
-    formUUID,
-    formJson,
-    encounterUUID || encounterUuid,
-    formSessionIntent,
-  );
+  const {
+    formJson: refinedFormJson,
+    isLoading: isLoadingFormJson,
+    formError,
+  } = useFormJson(formUUID, formJson, encounterUUID || encounterUuid, formSessionIntent);
 
   const { t } = useTranslation();
   const formSessionDate = useMemo(() => new Date(), []);
@@ -168,7 +167,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
   const handleFormSubmit = (values: Record<string, any>) => {
     // validate the form and its subforms (when present)
     let isSubmittable = true;
-    handlers.forEach(handler => {
+    handlers.forEach((handler) => {
       const result = handler?.validate?.(values);
       if (!result) {
         isSubmittable = false;
@@ -182,7 +181,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
       });
 
       Promise.all(submissions)
-        .then(async results => {
+        .then(async (results) => {
           if (mode === 'edit') {
             showToast({
               description: t('updatedRecordDescription', 'The patient encounter was updated'),
@@ -207,7 +206,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                     {
                       patient,
                       sessionMode,
-                      encounters: results.map(encounterResult => encounterResult.data),
+                      encounters: results.map((encounterResult) => encounterResult.data),
                     },
                     config,
                   );
@@ -228,7 +227,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
           }
           onSubmit?.();
         })
-        .catch(error => {
+        .catch((error) => {
           const errorMessages = extractErrorMessagesFromResponse(error);
           showToast({
             description: t('errorDescription', errorMessages.join(', ')),
@@ -252,7 +251,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
         handleFormSubmit(values);
         setSubmitting(false);
       }}>
-      {props => {
+      {(props) => {
         setIsFormTouched(props.dirty);
 
         return (
@@ -262,7 +261,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
             ) : (
               <div className={styles.ohriFormContainer}>
                 {showWarningModal ? (
-                  <WarningModal onClose={handleClose} onShowWarningModal={setShowWarningModal} t={t} />
+                  <WarningModal onCancel={onCancel} onShowWarningModal={setShowWarningModal} t={t} />
                 ) : null}
                 {isLoadingFormDependencies && (
                   <div className={styles.loader}>
@@ -326,7 +325,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                         <Button
                           kind="secondary"
                           onClick={() => {
-                            if (isFormTouched) {
+                            if (mode !== 'view' && isFormTouched) {
                               setShowWarningModal(true);
                               return;
                             }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

- This PR fixes the issue with the confirmation modal not closing the form upon clicking the "confirm" button. 

- This also fixes a follow up issue where the pop-up modal was showing even on view mode.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/openmrs/openmrs-form-engine-lib/assets/51090527/9a1643b9-d37a-4896-a6ab-4b46bfc39235


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
