### PR TITLE
(fix) fix error editing obs group with more than one repeating group

### DIFF
--- a/__mocks__/forms/ohri-forms/obs-group-test_form.json
+++ b/__mocks__/forms/ohri-forms/obs-group-test_form.json
@@ -1,0 +1,137 @@
+{
+    "name": "ObsGroup Test Form",
+    "version": "1",
+    "published": true,
+    "retired": false,
+    "pages": [
+      {
+        "label": "Introduction",
+        "sections": [
+          {
+            "label": "",
+            "isExpanded": "true",
+            "questions": [
+              {
+                "type": "markdown",
+                "questionOptions": {
+                  "rendering": "markdown"
+                },
+                "id": "fooMarkdown",
+                "value": [
+                  "**Use this form to:** Test Obs Group behaviour"
+                ]
+              }
+            ]
+          }
+        ]
+      }, 
+      {
+        "label": "Obs Group Page",
+        "sections": [
+          {
+            "label": "Group Section",
+            "isExpanded": "true",
+            "questions": [
+              {
+                "id": "myGroup",
+                "label": "My Group",
+                "type": "obsGroup",
+                "questionOptions": {
+                  "rendering": "repeating",
+                  "concept": "1c70c490-cafa-4c95-9fdd-a30b62bb78b8"
+                },
+                "behaviours":[
+                  {
+                    "intent":"*",
+                    "required":"false",
+                    "unspecified":"false",
+                    "hide":{
+                      "hideWhenExpression":""
+                    },
+                    "validators":[]
+                  }
+                ],
+                "questions": [
+                  {
+                    "label": "Sex",
+                    "type":"obs",
+                    "required":"true",
+                    "questionOptions":{
+                      "rendering":"radio",
+                      "concept":"1587AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                      "answers":[
+                        {
+                          "concept":"1535AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                          "label":"Female"
+                        },
+                        {
+                          "concept":"1534AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                          "label":"Male"
+                        }
+                      ]
+                    },
+                    "id":"childSex",
+                    "behaviours":[
+                      {
+                        "intent":"*",
+                        "required":"true",
+                        "unspecified":"true",
+                        "hide":{
+                          "hideWhenExpression":"false"
+                        },
+                        "validators":[]
+                      }
+                    ]
+                  },
+                  {
+                    "label": "Date of Birth",
+                    "type": "obs",
+                    "questionOptions": {
+                      "rendering": "date",
+                      "concept": "164802AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                      "weeksList": ""
+                    },
+                    "id": "birthDate",
+                    "behaviours": [
+                      {
+                        "intent": "*",
+                        "required": "true",
+                        "unspecified": "true",
+                        "hide": {
+                          "hideWhenExpression": "false"
+                        },
+                        "validators": [
+                          {
+                            "type": "date",
+                            "allowFutureDates": "false"
+                          },
+                          {
+                            "type": "js_expression",
+                            "failsWhenExpression": "!isDateEqualTo(myValue, useFieldValue('visit_date'))",
+                            "message": "Child birth date should be the same as the visit date!"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "availableIntents": [
+      {
+        "intent": "*",
+        "display": "ObsGroup Test Form"
+      }
+    ],
+    "processor": "EncounterFormProcessor",
+    "uuid": "8f713e0e-94a0-3c57-9024-69520933802a",
+    "referencedForms": [],
+    "encounterType": "7e54cd64-f9c3-11eb-8e6a-57478ce139b0",
+    "encounter": "Obs Group Test",
+    "allowUnspecifiedAll": true
+  }
+  

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -99,6 +99,7 @@ export interface OHRIFormField {
   type: string;
   questionOptions: OHRIFormQuestionOptions;
   id: string;
+  uuid?: string;
   groupId?: string;
   questions?: Array<OHRIFormField>;
   value?: any;

--- a/src/components/encounter/ohri-encounter-form.component.tsx
+++ b/src/components/encounter/ohri-encounter-form.component.tsx
@@ -420,7 +420,6 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
       .filter((field) => !field.questionOptions.isTransient && field.questionOptions.rendering !== 'file')
       .forEach((field) => {
         if (field.type == 'obsGroup') {
-          const obsGroupUuid = encounter?.obs?.find((m) => m.concept.uuid == field.questionOptions.concept)?.uuid;
           const obsGroup = {
             person: patient?.id,
             obsDatetime: encounterDate,
@@ -428,7 +427,7 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
             location: encounterLocation,
             order: null,
             groupMembers: [],
-            uuid: obsGroupUuid,
+            uuid: field.uuid,
             voided: false,
           };
           let hasValue = false;

--- a/src/components/repeat/helpers.ts
+++ b/src/components/repeat/helpers.ts
@@ -6,8 +6,9 @@ export function cloneObsGroup(srcField: OHRIFormField, obsGroup: any, idSuffix: 
   const clonedField = cloneDeep(srcField) as OHRIFormField;
   clonedField.questionOptions.repeatOptions = { ...(clonedField.questionOptions.repeatOptions ?? {}), isCloned: true };
   clonedField.value = obsGroup;
+  clonedField.uuid = obsGroup?.uuid;
   clonedField.id = `${clonedField.id}_${idSuffix}`;
-  clonedField.questions.forEach(childField => {
+  clonedField.questions.forEach((childField) => {
     originalGroupMembersIds.push(childField.id);
     childField.id = `${childField.id}_${idSuffix}`;
     childField['groupId'] = clonedField.id;
@@ -23,7 +24,7 @@ export function cloneObsGroup(srcField: OHRIFormField, obsGroup: any, idSuffix: 
       );
     }
     if (childField.validators?.length) {
-      childField.validators.forEach(validator => {
+      childField.validators.forEach((validator) => {
         if (validator.type === 'js_expression') {
           validator.failsWhenExpression = updateFieldIdInExpression(
             validator.failsWhenExpression,
@@ -46,7 +47,7 @@ export function cloneObsGroup(srcField: OHRIFormField, obsGroup: any, idSuffix: 
 
 export const updateFieldIdInExpression = (expression: string, index: number, questionIds: string[]) => {
   let uniqueQuestionIds = [...new Set(questionIds)];
-  uniqueQuestionIds.forEach(id => {
+  uniqueQuestionIds.forEach((id) => {
     if (expression.match(id)) {
       expression = expression.replace(new RegExp(id, 'g'), `${id}_${index}`);
     }

--- a/src/components/repeat/ohri-repeat.component.tsx
+++ b/src/components/repeat/ohri-repeat.component.tsx
@@ -18,16 +18,19 @@ export const showAddButton = (limit: string | number, counter: number) => {
 
 export const OHRIRepeat: React.FC<OHRIFormFieldProps> = ({ question, onChange }) => {
   const { t } = useTranslation();
-  const { fields: allFormFields, encounterContext, obsGroupsToVoid, formFieldHandlers } = React.useContext(
-    OHRIFormContext,
-  );
+  const {
+    fields: allFormFields,
+    encounterContext,
+    obsGroupsToVoid,
+    formFieldHandlers,
+  } = React.useContext(OHRIFormContext);
   const { values, setValues } = useFormikContext();
   const [counter, setCounter] = useState(1);
   const [obsGroups, setObsGroups] = useState([]);
 
   useEffect(() => {
     const groups = allFormFields.filter(
-      field => field.questionOptions.concept === question.questionOptions.concept && field.id.startsWith(question.id),
+      (field) => field.questionOptions.concept === question.questionOptions.concept && field.id.startsWith(question.id),
     );
     setCounter(groups.length);
     setObsGroups(groups);
@@ -37,7 +40,7 @@ export const OHRIRepeat: React.FC<OHRIFormFieldProps> = ({ question, onChange })
     (counter: number) => {
       const clonedGroupingField = cloneObsGroup(question, null, counter);
       // run necessary expressions
-      clonedGroupingField.questions.forEach(childField => {
+      clonedGroupingField.questions.forEach((childField) => {
         if (childField.hide?.hideWhenExpression) {
           childField.isHidden = evaluateExpression(
             childField.hide.hideWhenExpression,
@@ -60,7 +63,7 @@ export const OHRIRepeat: React.FC<OHRIFormFieldProps> = ({ question, onChange })
               mode: encounterContext.sessionMode,
               patient: encounterContext.patient,
             },
-          ).then(result => {
+          ).then((result) => {
             if (!isEmpty(result)) {
               values[childField.id] = result;
               formFieldHandlers[childField.type].handleFieldSubmission(childField, result, encounterContext);
@@ -83,12 +86,12 @@ export const OHRIRepeat: React.FC<OHRIFormFieldProps> = ({ question, onChange })
       delete question.value.value;
       obsGroupsToVoid.push(question.value);
     }
-    setObsGroups(obsGroups.filter(q => q.id !== question.id));
+    setObsGroups(obsGroups.filter((q) => q.id !== question.id));
 
     // cleanup
-    const dueFields = [question.id, ...question.questions.map(q => q.id)];
-    dueFields.forEach(field => {
-      const index = allFormFields.findIndex(f => f.id === field);
+    const dueFields = [question.id, ...question.questions.map((q) => q.id)];
+    dueFields.forEach((field) => {
+      const index = allFormFields.findIndex((f) => f.id === field);
       allFormFields.splice(index, 1);
       delete values[field];
     });
@@ -96,7 +99,7 @@ export const OHRIRepeat: React.FC<OHRIFormFieldProps> = ({ question, onChange })
 
   const nodes = obsGroups.map((question, index) => {
     const deleteControl =
-      obsGroups.length > 1 ? (
+      obsGroups.length > 1 && encounterContext.sessionMode !== 'view' ? (
         <div>
           <div className={styles.removeButton}>
             <Button
@@ -138,7 +141,7 @@ export const OHRIRepeat: React.FC<OHRIFormFieldProps> = ({ question, onChange })
             kind="tertiary"
             onClick={() => {
               const nextCount = counter + 1;
-              handleAdd(nextCount);
+              handleAdd(counter);
               setCounter(nextCount);
             }}>
             <span>{question.questionOptions.repeatOptions?.addText || `${t('add', 'Add')}`}</span>

--- a/src/hooks/useInitialValues.ts
+++ b/src/hooks/useInitialValues.ts
@@ -79,6 +79,12 @@ export function useInitialValues(
             initialValues[`${field.id}-unspecified`] = !!!existingVal;
           }
         });
+      repeatableFields.forEach((field) => {
+        let initializedRepeatField = formFields.find((initField) => initField.id === field.id);
+        if (initializedRepeatField) {
+          initializedRepeatField.uuid = initializedRepeatField.questions[0]?.value?.obsGroup?.uuid;
+        }
+      });
       const flatenedFields = repeatableFields.flatMap((field) => {
         let counter = 1;
         const unMappedGroups = encounter.obs.filter(

--- a/src/ohri-form.component.test.tsx
+++ b/src/ohri-form.component.test.tsx
@@ -1,64 +1,73 @@
-import { render, fireEvent, screen, cleanup, act, waitFor } from '@testing-library/react';
-import { when } from "jest-when";
-import * as api from "../src/api/api";
-import React from "react";
-import OHRIForm from "./ohri-form.component";
-import hts_poc_1_1 from "../__mocks__/packages/hiv/forms/hts_poc/1.1.json";
-import bmi_form from "../__mocks__/forms/ohri-forms/bmi-test-form.json";
-import bsa_form from "../__mocks__/forms/ohri-forms/bsa-test-form.json";
-import edd_form from "../__mocks__/forms/ohri-forms/edd-test-form.json";
-import filter_answer_options_form from "../__mocks__/forms/ohri-forms/filter-answer-options-test-form.json";
-import test_enrolment_form from "../__mocks__/forms/ohri-forms/test-enrolment-form.json";
-import next_visit_form from "../__mocks__/forms/ohri-forms/next-visit-test-form.json";
-import months_on_art_form from "../__mocks__/forms/ohri-forms/months-on-art-form.json";
-import age_validation_form from "../__mocks__/forms/ohri-forms/age-validation-form.json";
-import viral_load_status_form from "../__mocks__/forms/ohri-forms/viral-load-status-form.json";
-import reference_by_mapping_form from "../__mocks__/forms/ohri-forms/reference-by-mapping-form.json";
-import external_data_source_form from "../__mocks__/forms/ohri-forms/external_data_source_form.json";
-import mock_concepts from "../__mocks__/concepts.mock.json";
-import { mockPatient } from "../__mocks__/patient.mock";
-import { mockSessionDataResponse } from "../__mocks__/session.mock";
-import demoHtsOpenmrsForm from "../__mocks__/forms/omrs-forms/demo_hts-form.json";
-import demoHtsOhriForm from "../__mocks__/forms/ohri-forms/demo_hts-form.json";
+import {
+  render,
+  fireEvent,
+  screen,
+  cleanup,
+  act,
+  waitFor,
+  getByText,
+  prettyDOM,
+  findAllByRole,
+  getAllByRole,
+  queryAllByRole,
+} from '@testing-library/react';
+import { when } from 'jest-when';
+import * as api from '../src/api/api';
+import React from 'react';
+import OHRIForm from './ohri-form.component';
+import hts_poc_1_1 from '../__mocks__/packages/hiv/forms/hts_poc/1.1.json';
+import bmi_form from '../__mocks__/forms/ohri-forms/bmi-test-form.json';
+import bsa_form from '../__mocks__/forms/ohri-forms/bsa-test-form.json';
+import edd_form from '../__mocks__/forms/ohri-forms/edd-test-form.json';
+import filter_answer_options_form from '../__mocks__/forms/ohri-forms/filter-answer-options-test-form.json';
+import test_enrolment_form from '../__mocks__/forms/ohri-forms/test-enrolment-form.json';
+import next_visit_form from '../__mocks__/forms/ohri-forms/next-visit-test-form.json';
+import months_on_art_form from '../__mocks__/forms/ohri-forms/months-on-art-form.json';
+import age_validation_form from '../__mocks__/forms/ohri-forms/age-validation-form.json';
+import viral_load_status_form from '../__mocks__/forms/ohri-forms/viral-load-status-form.json';
+import reference_by_mapping_form from '../__mocks__/forms/ohri-forms/reference-by-mapping-form.json';
+import external_data_source_form from '../__mocks__/forms/ohri-forms/external_data_source_form.json';
+import mock_concepts from '../__mocks__/concepts.mock.json';
+import { mockPatient } from '../__mocks__/patient.mock';
+import { mockSessionDataResponse } from '../__mocks__/session.mock';
+import demoHtsOpenmrsForm from '../__mocks__/forms/omrs-forms/demo_hts-form.json';
+import demoHtsOhriForm from '../__mocks__/forms/ohri-forms/demo_hts-form.json';
+import obsGroup_test_form from '../__mocks__/forms/ohri-forms/obs-group-test_form.json';
 
 import {
   assertFormHasAllFields,
+  findAllRadioGroupInputs,
+  findAllRadioGroupMembers,
+  findAllTextOrDateInputs,
   findMultiSelectInput,
   findNumberInput,
+  findRadioGroupInput,
   findRadioGroupMember,
   findSelectInput,
   findTextOrDateInput,
-} from "./utils/test-utils";
-import { mockVisit } from "../__mocks__/visit.mock";
+} from './utils/test-utils';
+import { mockVisit } from '../__mocks__/visit.mock';
 
 //////////////////////////////////////////
 ////// Base setup
 //////////////////////////////////////////
 const mockUrl = `/ws/rest/v1/encounter?v=full`;
-const patientUUID = "8673ee4f-e2ab-4077-ba55-4980f408773e";
+const patientUUID = '8673ee4f-e2ab-4077-ba55-4980f408773e';
 const visit = mockVisit;
 const mockOpenmrsFetch = jest.fn();
-const formsResourcePath = when((url: string) =>
-  url.includes("/ws/rest/v1/form/")
-);
-const clobdataResourcePath = when((url: string) =>
-  url.includes("/ws/rest/v1/clobdata/")
-);
-global.ResizeObserver = require("resize-observer-polyfill");
-when(mockOpenmrsFetch)
-  .calledWith(formsResourcePath)
-  .mockReturnValue({ data: demoHtsOpenmrsForm });
-when(mockOpenmrsFetch)
-  .calledWith(clobdataResourcePath)
-  .mockReturnValue({ data: demoHtsOhriForm });
+const formsResourcePath = when((url: string) => url.includes('/ws/rest/v1/form/'));
+const clobdataResourcePath = when((url: string) => url.includes('/ws/rest/v1/clobdata/'));
+global.ResizeObserver = require('resize-observer-polyfill');
+when(mockOpenmrsFetch).calledWith(formsResourcePath).mockReturnValue({ data: demoHtsOpenmrsForm });
+when(mockOpenmrsFetch).calledWith(clobdataResourcePath).mockReturnValue({ data: demoHtsOhriForm });
 
-  const locale = window.i18next.language == 'en'? 'en-GB' : window.i18next.language;
+const locale = window.i18next.language == 'en' ? 'en-GB' : window.i18next.language;
 
 //////////////////////////////////////////
 ////// Mocks
 //////////////////////////////////////////
-jest.mock("@openmrs/esm-framework", () => {
-  const originalModule = jest.requireActual("@openmrs/esm-framework");
+jest.mock('@openmrs/esm-framework', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
 
   return {
     ...originalModule,
@@ -68,77 +77,57 @@ jest.mock("@openmrs/esm-framework", () => {
     getAsyncLifecycle: jest.fn(),
     usePatient: jest.fn().mockImplementation(() => ({ patient: mockPatient })),
     registerExtension: jest.fn(),
-    useSession: jest
-      .fn()
-      .mockImplementation(() => mockSessionDataResponse.data),
-    openmrsFetch: jest
-      .fn()
-      .mockImplementation((args) => mockOpenmrsFetch(args)),
+    useSession: jest.fn().mockImplementation(() => mockSessionDataResponse.data),
+    openmrsFetch: jest.fn().mockImplementation((args) => mockOpenmrsFetch(args)),
   };
 });
 
-jest.mock("../src/api/api", () => {
-  const originalModule = jest.requireActual("../src/api/api");
+jest.mock('../src/api/api', () => {
+  const originalModule = jest.requireActual('../src/api/api');
 
   return {
     ...originalModule,
-    getPreviousEncounter: jest
-      .fn()
-      .mockImplementation(() => Promise.resolve(null)),
-    fetchConceptNameByUuid: jest
-      .fn()
-      .mockImplementation(() => Promise.resolve(null)),
+    getPreviousEncounter: jest.fn().mockImplementation(() => Promise.resolve(null)),
+    fetchConceptNameByUuid: jest.fn().mockImplementation(() => Promise.resolve(null)),
     getConcept: jest.fn().mockImplementation(() => Promise.resolve(null)),
-    getLatestObs: jest
-      .fn()
-      .mockImplementation(() => Promise.resolve({ valueNumeric: 60 })),
-      saveEncounter: jest.fn(),
+    getLatestObs: jest.fn().mockImplementation(() => Promise.resolve({ valueNumeric: 60 })),
+    saveEncounter: jest.fn(),
   };
 });
 
-describe("OHRI Forms:", () => {
+describe('OHRI Forms:', () => {
   afterEach(() => {
     cleanup();
     jest.useRealTimers();
   });
 
-  it("Should render by the form json without dying", async () => {
+  it('Should render by the form json without dying', async () => {
     await act(async () => renderForm(null, hts_poc_1_1));
+    await assertFormHasAllFields(screen, [{ fieldName: 'When was the HIV test conducted?', fieldType: 'date' }]);
+  });
+
+  it('Should render by the form UUID without dying', async () => {
+    await act(async () => renderForm('955ab92f-f93e-4dc0-9c68-b7b2346def55', null));
     await assertFormHasAllFields(screen, [
-      { fieldName: "When was the HIV test conducted?", fieldType: "date" },
+      { fieldName: 'When was the HIV test conducted?', fieldType: 'date' },
+      { fieldName: 'Community service delivery point', fieldType: 'select' },
+      { fieldName: 'TB screening', fieldType: 'combobox' },
     ]);
   });
 
-  it("Should render by the form UUID without dying", async () => {
-    await act(async () =>
-      renderForm("955ab92f-f93e-4dc0-9c68-b7b2346def55", null)
-    );
-    await assertFormHasAllFields(screen, [
-      { fieldName: "When was the HIV test conducted?", fieldType: "date" },
-      { fieldName: "Community service delivery point", fieldType: "select" },
-      { fieldName: "TB screening", fieldType: "combobox" },
-    ]);
-  });
-
-  it("Should demonstrate behaviour driven by form intents", async () => {
+  it('Should demonstrate behaviour driven by form intents', async () => {
     // HTS_INTENT_A
-    await act(async () =>
-      renderForm("955ab92f-f93e-4dc0-9c68-b7b2346def55", null, "HTS_INTENT_A")
-    );
+    await act(async () => renderForm('955ab92f-f93e-4dc0-9c68-b7b2346def55', null, 'HTS_INTENT_A'));
     await assertFormHasAllFields(screen, [
-      { fieldName: "When was the HIV test conducted?", fieldType: "date" },
-      { fieldName: "TB screening", fieldType: "combobox" },
+      { fieldName: 'When was the HIV test conducted?', fieldType: 'date' },
+      { fieldName: 'TB screening', fieldType: 'combobox' },
     ]);
     try {
-      await findSelectInput(screen, "Community service delivery point");
-      fail(
-        "Field with title 'Community service delivery point' should not be found"
-      );
+      await findSelectInput(screen, 'Community service delivery point');
+      fail("Field with title 'Community service delivery point' should not be found");
     } catch (err) {
       expect(
-        err.message.includes(
-          'Unable to find role="button" and name "Community service delivery point"'
-        )
+        err.message.includes('Unable to find role="button" and name "Community service delivery point"'),
       ).toBeTruthy();
     }
 
@@ -146,26 +135,20 @@ describe("OHRI Forms:", () => {
     cleanup();
 
     // HTS_INTENT_B
-    await act(async () =>
-      renderForm("955ab92f-f93e-4dc0-9c68-b7b2346def55", null, "HTS_INTENT_B")
-    );
+    await act(async () => renderForm('955ab92f-f93e-4dc0-9c68-b7b2346def55', null, 'HTS_INTENT_B'));
     await assertFormHasAllFields(screen, [
-      { fieldName: "When was the HIV test conducted?", fieldType: "date" },
-      { fieldName: "Community service delivery point", fieldType: "select" },
+      { fieldName: 'When was the HIV test conducted?', fieldType: 'date' },
+      { fieldName: 'Community service delivery point', fieldType: 'select' },
     ]);
     try {
-      await findMultiSelectInput(screen, "TB screening");
+      await findMultiSelectInput(screen, 'TB screening');
       fail("Field with title 'TB screening' should not be found");
     } catch (err) {
-      expect(
-        err.message.includes(
-          'Unable to find role="combobox" and name "TB screening"'
-        )
-      ).toBeTruthy();
+      expect(err.message.includes('Unable to find role="combobox" and name "TB screening"')).toBeTruthy();
     }
   });
   // Form submission
-  describe("Form submission", () => {
+  describe('Form submission', () => {
     it('Should validate form submission', async () => {
       // Mock the form submission function to simulate success
       const saveEncounterMock = jest.spyOn(api, 'saveEncounter');
@@ -212,7 +195,7 @@ describe("OHRI Forms:", () => {
       fireEvent.click(generalPopulationField);
 
       // Assert that Transient Field has a value
-      expect(enrolmentDateField.value).toBe("09/09/2023")
+      expect(enrolmentDateField.value).toBe('09/09/2023');
 
       // Simulate a successful form submission
       await act(async () => {
@@ -222,296 +205,324 @@ describe("OHRI Forms:", () => {
       // Add assertions for transient field behaviour
       const [abortController, encounter, encounterUuid] = saveEncounterMock.mock.calls[0];
       expect(encounter.obs.length).toEqual(3);
-      expect(encounter.obs.find(obs => obs.formFieldPath === "ohri-forms-hivEnrolmentDate")).toBeUndefined();
-
+      expect(encounter.obs.find((obs) => obs.formFieldPath === 'ohri-forms-hivEnrolmentDate')).toBeUndefined();
     });
-
   });
 
-
-  describe("Filter Answer Options", () => {
-    it("should filter dropdown options based on value in count input field", async () => {
+  describe('Filter Answer Options', () => {
+    it('should filter dropdown options based on value in count input field', async () => {
       //setup
       await act(async () => renderForm(null, filter_answer_options_form));
-      const recommendationDropdown = await findSelectInput(
-        screen,
-        "Testing Recommendations"
-      );
-      const testCountField = await findNumberInput(
-        screen,
-        "How many times have you tested in the past?"
-      );
+      const recommendationDropdown = await findSelectInput(screen, 'Testing Recommendations');
+      const testCountField = await findNumberInput(screen, 'How many times have you tested in the past?');
       // open dropdown
       fireEvent.click(recommendationDropdown);
-      expect(
-        screen.queryByRole("option", { name: /Perfect testing/i })
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole("option", { name: /Minimal testing/i })
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole("option", { name: /Un-decisive/i })
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole("option", { name: /Not ideal/i })
-      ).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /Perfect testing/i })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /Minimal testing/i })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /Un-decisive/i })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /Not ideal/i })).toBeInTheDocument();
       // close dropdown
       fireEvent.click(recommendationDropdown);
       // provide a value greater than 5
-      fireEvent.blur(testCountField, { target: { value: "6" } });
+      fireEvent.blur(testCountField, { target: { value: '6' } });
       // re-open dropdown
       fireEvent.click(recommendationDropdown);
       // verify
-      expect(testCountField.value).toBe("6");
-      expect(
-        screen.queryByRole("option", { name: /Perfect testing/i })
-      ).toBeNull();
-      expect(
-        screen.queryByRole("option", { name: /Minimal testing/i })
-      ).toBeNull();
-      expect(
-        screen.queryByRole("option", { name: /Un-decisive/i })
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole("option", { name: /Not ideal/i })
-      ).toBeInTheDocument();
+      expect(testCountField.value).toBe('6');
+      expect(screen.queryByRole('option', { name: /Perfect testing/i })).toBeNull();
+      expect(screen.queryByRole('option', { name: /Minimal testing/i })).toBeNull();
+      expect(screen.queryByRole('option', { name: /Un-decisive/i })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /Not ideal/i })).toBeInTheDocument();
     });
   });
 
-  describe("Calcuated values", () => {
+  describe('Calcuated values', () => {
     afterEach(() => {
       cleanup();
     });
 
-    it("Should evaluate BMI", async () => {
+    it('Should evaluate BMI', async () => {
       // setup
       await act(async () => renderForm(null, bmi_form));
 
       // const bmiField = (await screen.findByRole('textbox', { name: 'BMI' })) as HTMLInputElement;
-      const bmiField = await findTextOrDateInput(screen, "BMI");
-      const heightField = await findNumberInput(screen, "Height");
-      const weightField = await findNumberInput(screen, "Weight");
-      await act(async () => expect(heightField.value).toBe(""));
-      await act(async () => expect(weightField.value).toBe(""));
-      await act(async () => expect(bmiField.value).toBe(""));
+      const bmiField = await findTextOrDateInput(screen, 'BMI');
+      const heightField = await findNumberInput(screen, 'Height');
+      const weightField = await findNumberInput(screen, 'Weight');
+      await act(async () => expect(heightField.value).toBe(''));
+      await act(async () => expect(weightField.value).toBe(''));
+      await act(async () => expect(bmiField.value).toBe(''));
 
       // replay
       fireEvent.blur(heightField, { target: { value: 150 } });
       fireEvent.blur(weightField, { target: { value: 50 } });
 
       // verify
-      await act(async () => expect(heightField.value).toBe("150"));
-      await act(async () => expect(weightField.value).toBe("50"));
-      await act(async () => expect(bmiField.value).toBe("22.2"));
+      await act(async () => expect(heightField.value).toBe('150'));
+      await act(async () => expect(weightField.value).toBe('50'));
+      await act(async () => expect(bmiField.value).toBe('22.2'));
     });
 
-    it("Should evaluate BSA", async () => {
+    it('Should evaluate BSA', async () => {
       // setup
       await act(async () => renderForm(null, bsa_form));
 
-      const bsaField = await findTextOrDateInput(screen, "BSA");
-      const heightField = await findNumberInput(screen, "Height");
-      const weightField = await findNumberInput(screen, "Weight");
-      await act(async () => expect(heightField.value).toBe(""));
-      await act(async () => expect(weightField.value).toBe(""));
-      await act(async () => expect(bsaField.value).toBe(""));
+      const bsaField = await findTextOrDateInput(screen, 'BSA');
+      const heightField = await findNumberInput(screen, 'Height');
+      const weightField = await findNumberInput(screen, 'Weight');
+      await act(async () => expect(heightField.value).toBe(''));
+      await act(async () => expect(weightField.value).toBe(''));
+      await act(async () => expect(bsaField.value).toBe(''));
 
       // replay
       fireEvent.blur(heightField, { target: { value: 190.5 } });
       fireEvent.blur(weightField, { target: { value: 95 } });
 
       // verify
-      await act(async () => expect(heightField.value).toBe("190.5"));
-      await act(async () => expect(weightField.value).toBe("95"));
-      await act(async () => expect(bsaField.value).toBe("2.24"));
+      await act(async () => expect(heightField.value).toBe('190.5'));
+      await act(async () => expect(weightField.value).toBe('95'));
+      await act(async () => expect(bsaField.value).toBe('2.24'));
     });
 
-    it("Should evaluate EDD", async () => {
+    it('Should evaluate EDD', async () => {
       // setup
       await act(async () => renderForm(null, edd_form));
-      const eddField = await findTextOrDateInput(screen, "EDD");
-      const lmpField = await findTextOrDateInput(screen, "LMP");
+      const eddField = await findTextOrDateInput(screen, 'EDD');
+      const lmpField = await findTextOrDateInput(screen, 'LMP');
 
-      await act(async () => expect(eddField.value).toBe(""));
-      await act(async () => expect(lmpField.value).toBe(""));
+      await act(async () => expect(eddField.value).toBe(''));
+      await act(async () => expect(lmpField.value).toBe(''));
 
       // replay
-      fireEvent.change(lmpField, { target: { value: "2022-07-06" } });
+      fireEvent.change(lmpField, { target: { value: '2022-07-06' } });
 
       // verify
-      await act(async () =>
-        expect(lmpField.value).toBe(
-          new Date("2022-07-06").toLocaleDateString(locale)
-        )
-      );
-      await act(async () =>
-        expect(eddField.value).toBe(
-          new Date("2023-04-12").toLocaleDateString(locale)
-        )
-      );
+      await act(async () => expect(lmpField.value).toBe(new Date('2022-07-06').toLocaleDateString(locale)));
+      await act(async () => expect(eddField.value).toBe(new Date('2023-04-12').toLocaleDateString(locale)));
     });
 
-    it("Should evaluate months on ART", async () => {
+    it('Should evaluate months on ART', async () => {
       // setup
       await act(async () => renderForm(null, months_on_art_form));
       jest.useFakeTimers();
       jest.setSystemTime(new Date(2022, 9, 1));
-      let artStartDateField = (await screen.findByRole("textbox", {
+      let artStartDateField = (await screen.findByRole('textbox', {
         name: /Antiretroviral treatment start date/,
       })) as HTMLInputElement;
-      let monthsOnARTField = (await screen.findByRole("spinbutton", {
+      let monthsOnARTField = (await screen.findByRole('spinbutton', {
         name: /Months on ART/,
       })) as HTMLInputElement;
-      let assumeTodayToBe = "7/11/2022";
+      let assumeTodayToBe = '7/11/2022';
 
-      await act(async () => expect(artStartDateField.value).toBe(""));
-      await act(async () => expect(assumeTodayToBe).toBe("7/11/2022"));
-      await act(async () => expect(monthsOnARTField.value).toBe(""));
+      await act(async () => expect(artStartDateField.value).toBe(''));
+      await act(async () => expect(assumeTodayToBe).toBe('7/11/2022'));
+      await act(async () => expect(monthsOnARTField.value).toBe(''));
 
       // replay
-      fireEvent.blur(artStartDateField, { target: { value: "05/02/2022" } });
+      fireEvent.blur(artStartDateField, { target: { value: '05/02/2022' } });
 
       // verify
       await act(async () =>
-        expect(artStartDateField.value).toBe(
-          new Date("2022-02-05T00:00:00.000+0000").toLocaleDateString(locale)
-        )
+        expect(artStartDateField.value).toBe(new Date('2022-02-05T00:00:00.000+0000').toLocaleDateString(locale)),
       );
-      await act(async () => expect(assumeTodayToBe).toBe("7/11/2022"));
-      await act(async () => expect(monthsOnARTField.value).toBe("7"));
+      await act(async () => expect(assumeTodayToBe).toBe('7/11/2022'));
+      await act(async () => expect(monthsOnARTField.value).toBe('7'));
     });
 
-    it("Should evaluate viral load status", async () => {
+    it('Should evaluate viral load status', async () => {
       // setup
       await act(async () => renderForm(null, viral_load_status_form));
-      let viralLoadCountField = (await screen.findByRole("spinbutton", {
+      let viralLoadCountField = (await screen.findByRole('spinbutton', {
         name: /Viral Load Count/,
       })) as HTMLInputElement;
-      let viralLoadStatusField = (await screen.findByRole("group", {
+      let viralLoadStatusField = (await screen.findByRole('group', {
         name: /Viral Load Status/,
       })) as HTMLInputElement;
-      let suppressedField = (await screen.findByRole("radio", {
+      let suppressedField = (await screen.findByRole('radio', {
         name: /Suppressed/,
       })) as HTMLInputElement;
-      let unsuppressedField = (await screen.findByRole("radio", {
+      let unsuppressedField = (await screen.findByRole('radio', {
         name: /Unsuppressed/,
       })) as HTMLInputElement;
 
-      await act(async () => expect(viralLoadCountField.value).toBe(""));
+      await act(async () => expect(viralLoadCountField.value).toBe(''));
       await act(async () => expect(viralLoadStatusField.value).toBe(undefined));
 
       // replay
       fireEvent.blur(viralLoadCountField, { target: { value: 30 } });
 
       // verify
-      await act(async () => expect(viralLoadCountField.value).toBe("30"));
+      await act(async () => expect(viralLoadCountField.value).toBe('30'));
       await act(async () => expect(suppressedField).toBeChecked());
       await act(async () => expect(unsuppressedField).not.toBeChecked());
     });
 
-    it("Should only show question when age is under 5", async () => {
+    it('Should only show question when age is under 5', async () => {
       // setup
       await act(async () => renderForm(null, age_validation_form));
-      let enrollmentDate = (await screen.findByRole("textbox", {
+      let enrollmentDate = (await screen.findByRole('textbox', {
         name: /enrollmentDate/,
       })) as HTMLInputElement;
 
-      await act(async () => expect(enrollmentDate.value).toBe(""));
+      await act(async () => expect(enrollmentDate.value).toBe(''));
       fireEvent.blur(enrollmentDate, {
-        target: { value: "1975-07-06T00:00:00.000Z" },
+        target: { value: '1975-07-06T00:00:00.000Z' },
       });
 
-      let mrn = (await screen.findByRole("textbox", {
+      let mrn = (await screen.findByRole('textbox', {
         name: /MRN/,
       })) as HTMLInputElement;
-      await act(async () => expect(mrn.value).toBe(""));
+      await act(async () => expect(mrn.value).toBe(''));
 
       // verify
       await act(async () =>
-        expect(enrollmentDate.value).toBe(
-          new Date("1975-07-06T00:00:00.000Z").toLocaleDateString(locale)
-        )
+        expect(enrollmentDate.value).toBe(new Date('1975-07-06T00:00:00.000Z').toLocaleDateString(locale)),
       );
-      await act(async () => expect(mrn.value).toBe(""));
+      await act(async () => expect(mrn.value).toBe(''));
       await act(async () => expect(mrn).toBeVisible());
     });
 
-    it("Should load initial value from external arbitrary data source", async () => {
+    it('Should load initial value from external arbitrary data source', async () => {
       // setup
       await act(async () => renderForm(null, external_data_source_form));
-      const bodyWeightField = await findNumberInput(screen, "Body Weight");
+      const bodyWeightField = await findNumberInput(screen, 'Body Weight');
 
       // verify
-      await act(async () => expect(bodyWeightField.value).toBe("60"));
+      await act(async () => expect(bodyWeightField.value).toBe('60'));
     });
 
     // FIXME: This test passes locally but fails in the CI environment
-    xit("Should evaluate next visit date", async () => {
+    xit('Should evaluate next visit date', async () => {
       // setup
       await act(async () => renderForm(null, next_visit_form));
-      let followupDateField = (await screen.findByRole("textbox", {
+      let followupDateField = (await screen.findByRole('textbox', {
         name: /Followup Date/,
       })) as HTMLInputElement;
-      let arvDispensedInDaysField = (await screen.findByRole("spinbutton", {
+      let arvDispensedInDaysField = (await screen.findByRole('spinbutton', {
         name: /ARV dispensed in days/,
       })) as HTMLInputElement;
-      let nextVisitDateField = (await screen.findByRole("textbox", {
+      let nextVisitDateField = (await screen.findByRole('textbox', {
         name: /Next visit date/,
       })) as HTMLInputElement;
 
-      await act(async () => expect(followupDateField.value).toBe(""));
-      await act(async () => expect(arvDispensedInDaysField.value).toBe(""));
-      await act(async () => expect(nextVisitDateField.value).toBe(""));
+      await act(async () => expect(followupDateField.value).toBe(''));
+      await act(async () => expect(arvDispensedInDaysField.value).toBe(''));
+      await act(async () => expect(nextVisitDateField.value).toBe(''));
 
       // replay
       fireEvent.blur(followupDateField, {
-        target: { value: "2022-07-06T00:00:00.000Z" },
+        target: { value: '2022-07-06T00:00:00.000Z' },
       });
       fireEvent.blur(arvDispensedInDaysField, { target: { value: 120 } });
 
       // verify
-      await act(async () => expect(followupDateField.value).toBe(""));
-      await act(async () => expect(arvDispensedInDaysField.value).toBe("120"));
-      await act(async () => expect(nextVisitDateField.value).toBe("11/3/2022"));
+      await act(async () => expect(followupDateField.value).toBe(''));
+      await act(async () => expect(arvDispensedInDaysField.value).toBe('120'));
+      await act(async () => expect(nextVisitDateField.value).toBe('11/3/2022'));
     });
   });
 
-  describe("Concept references", () => {
+  describe('Concept references', () => {
     const conceptResourcePath = when((url: string) =>
-      url.includes(
-        "/ws/rest/v1/concept?references=PIH:Occurrence of trauma,PIH:Yes,PIH:No,PIH:COUGH"
-      )
+      url.includes('/ws/rest/v1/concept?references=PIH:Occurrence of trauma,PIH:Yes,PIH:No,PIH:COUGH'),
     );
 
-    when(mockOpenmrsFetch)
-      .calledWith(conceptResourcePath)
-      .mockReturnValue({ data: mock_concepts });
+    when(mockOpenmrsFetch).calledWith(conceptResourcePath).mockReturnValue({ data: mock_concepts });
 
-    it("should add default labels based on concept display and substitute mapping references with uuids", async () => {
+    it('should add default labels based on concept display and substitute mapping references with uuids', async () => {
       await act(async () => renderForm(null, reference_by_mapping_form));
 
-      const yes = (await screen.findAllByRole("radio", {
-        name: "Yes",
+      const yes = (await screen.findAllByRole('radio', {
+        name: 'Yes',
       })) as Array<HTMLInputElement>;
-      const no = (await screen.findAllByRole("radio", {
-        name: "No",
+      const no = (await screen.findAllByRole('radio', {
+        name: 'No',
       })) as Array<HTMLInputElement>;
       await assertFormHasAllFields(screen, [
-        { fieldName: "Cough", fieldType: "radio" },
-        { fieldName: "Occurrence of trauma", fieldType: "radio" },
+        { fieldName: 'Cough', fieldType: 'radio' },
+        { fieldName: 'Occurrence of trauma', fieldType: 'radio' },
       ]);
-      await act(async () =>
-        expect(no[0].value).toBe("3cd6f86c-26fe-102b-80cb-0017a47871b2")
-      );
-      await act(async () =>
-        expect(no[1].value).toBe("3cd6f86c-26fe-102b-80cb-0017a47871b2")
-      );
-      await act(async () =>
-        expect(yes[0].value).toBe("3cd6f600-26fe-102b-80cb-0017a47871b2")
-      );
-      await act(async () =>
-        expect(yes[1].value).toBe("3cd6f600-26fe-102b-80cb-0017a47871b2")
-      );
+      await act(async () => expect(no[0].value).toBe('3cd6f86c-26fe-102b-80cb-0017a47871b2'));
+      await act(async () => expect(no[1].value).toBe('3cd6f86c-26fe-102b-80cb-0017a47871b2'));
+      await act(async () => expect(yes[0].value).toBe('3cd6f600-26fe-102b-80cb-0017a47871b2'));
+      await act(async () => expect(yes[1].value).toBe('3cd6f600-26fe-102b-80cb-0017a47871b2'));
+    });
+  });
+
+  describe('Obs Group', () => {
+    it('Should test addition of a repeating group', async () => {
+      //Setup
+      await act(async () => renderForm(null, obsGroup_test_form));
+      const femaleRadio = await findRadioGroupMember(screen, 'Female');
+      const maleRadio = await findRadioGroupMember(screen, 'Male');
+      const birthDateField = await findTextOrDateInput(screen, 'Date of Birth');
+
+      let femaleRadios = await findAllRadioGroupMembers(screen, 'Female');
+      let maleRadios = await findAllRadioGroupMembers(screen, 'Male');
+      let birthDateFields = await findAllTextOrDateInputs(screen, 'Date of Birth');
+
+      const addButton = await findSelectInput(screen, 'Add');
+
+      //Verify
+      await act(async () => expect(femaleRadio).toBeInTheDocument());
+      await act(async () => expect(maleRadio).toBeInTheDocument());
+      await act(async () => expect(birthDateField).toBeInTheDocument());
+      await act(async () => expect(femaleRadios.length).toBe(1));
+      await act(async () => expect(maleRadios.length).toBe(1));
+      await act(async () => expect(birthDateFields.length).toBe(1));
+      await act(async () => expect(addButton).toBeInTheDocument());
+
+      //Add repeat group
+      await act(async () => fireEvent.click(addButton));
+      femaleRadios = await findAllRadioGroupMembers(screen, 'Female');
+      maleRadios = await findAllRadioGroupMembers(screen, 'Male');
+      birthDateFields = await findAllTextOrDateInputs(screen, 'Date of Birth');
+
+      //verify repeat
+      await act(async () => expect(femaleRadios.length).toBe(2));
+      await act(async () => expect(maleRadios.length).toBe(2));
+      await act(async () => expect(birthDateFields.length).toBe(2));
+    });
+
+    fit('Should test deletion of a group', async () => {
+      //Setup
+      await act(async () => renderForm(null, obsGroup_test_form));
+      let femaleRadios = await findAllRadioGroupMembers(screen, 'Female');
+      let maleRadios = await findAllRadioGroupMembers(screen, 'Male');
+      let birthDateFields = await findAllTextOrDateInputs(screen, 'Date of Birth');
+
+      const addButton = await findSelectInput(screen, 'Add');
+
+      //Verify Initial state
+      await act(async () => expect(femaleRadios.length).toBe(1));
+      await act(async () => expect(maleRadios.length).toBe(1));
+      await act(async () => expect(birthDateFields.length).toBe(1));
+
+      //Add repeat group
+      await act(async () => fireEvent.click(addButton));
+
+      const deleteButton = await findSelectInput(screen, 'danger');
+      femaleRadios = await findAllRadioGroupMembers(screen, 'Female');
+      maleRadios = await findAllRadioGroupMembers(screen, 'Male');
+      birthDateFields = await findAllTextOrDateInputs(screen, 'Date of Birth');
+
+      //verify repeat
+      await act(async () => expect(femaleRadios.length).toBe(2));
+      await act(async () => expect(maleRadios.length).toBe(2));
+      await act(async () => expect(birthDateFields.length).toBe(2));
+      await act(async () => expect(deleteButton).toBeInTheDocument);
+
+      //delete group
+      await act(async () => fireEvent.click(deleteButton));
+      femaleRadios = await findAllRadioGroupMembers(screen, 'Female');
+      maleRadios = await findAllRadioGroupMembers(screen, 'Male');
+      birthDateFields = await findAllTextOrDateInputs(screen, 'Date of Birth');
+
+      //verify deletion
+      await act(async () => expect(deleteButton).not.toBeInTheDocument);
+      await act(async () => expect(femaleRadios.length).toBe(1));
+      await act(async () => expect(maleRadios.length).toBe(1));
+      await act(async () => expect(birthDateFields.length).toBe(1));
     });
   });
 
@@ -524,7 +535,7 @@ describe("OHRI Forms:", () => {
           patientUUID={patientUUID}
           formSessionIntent={intent}
           visit={visit}
-        />
+        />,
       );
     });
   }

--- a/src/utils/test-utils.ts
+++ b/src/utils/test-utils.ts
@@ -22,6 +22,18 @@ export async function findSelectInput(screen, name: string): Promise<HTMLInputEl
   return await screen.findByRole('button', { name });
 }
 
+export async function findAllRadioGroupInputs(screen, name: string): Promise<Array<HTMLInputElement>> {
+  return await screen.queryAllByRole('group', { name });
+}
+
+export async function findAllRadioGroupMembers(screen, name: string): Promise<Array<HTMLInputElement>> {
+  return await screen.queryAllByRole('radio', { name });
+}
+
+export async function findAllTextOrDateInputs(screen, name: string): Promise<Array<HTMLInputElement>> {
+  return await screen.queryAllByRole('textbox', { name });
+}
+
 const fieldTypeToGetterMap = {
   text: findTextOrDateInput,
   date: findTextOrDateInput,
@@ -38,5 +50,5 @@ export async function assertFormHasAllFields(screen, fields: Array<{ fieldName: 
   const fieldsInDom = await Promise.all(
     fields.map(({ fieldName, fieldType }) => fieldTypeToGetterMap[fieldType](screen, fieldName)),
   );
-  await Promise.all(fieldsInDom.map(field => expect(field).toBeInTheDocument()));
+  await Promise.all(fieldsInDom.map((field) => expect(field).toBeInTheDocument()));
 }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
There was an error while editing an obs group field with more than one repeating groups. This was because at the point of initializing fields, the first(default) group wasn't being assigned a uuid.
SOme other fixes on how the repeat group ids are generated and unit tests.

## Screenshots
N/A

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
