### PR TITLE
(fix) disappearance of config data on page reload

### DIFF
--- a/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
@@ -14,6 +14,9 @@ const question: OHRIFormField = {
     concept: '160540AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     datasource: {
       name: 'location_datasource',
+      config: {
+        tag: 'test-tag',
+      },
     },
   },
   value: null,
@@ -161,5 +164,28 @@ describe('UISelectExtended Component', () => {
       expect(screen.queryByText('Kololo')).not.toBeInTheDocument();
       expect(screen.queryByText('Muyenga')).not.toBeInTheDocument();
     });
+  });
+  it('Should set the correct value for the config parameter', async () => {
+    // Mock the data source fetch behavior
+    const expectedConfigValue = {
+      tag: 'test-tag',
+    };
+
+    // Mock the getRegisteredDataSource function
+    jest.mock('../../../registry/registry', () => ({
+      getRegisteredDataSource: jest.fn().mockResolvedValue({
+        fetchData: jest.fn().mockResolvedValue([]),
+        toUuidAndDisplay: (data) => data,
+        config: expectedConfigValue,
+      }),
+    }));
+
+    await act(async () => {
+      await renderForm({});
+    });
+    const config = question.questionOptions.datasource.config;
+
+    // Assert that the config is set with the expected configuration value
+    expect(config).toEqual(expectedConfigValue);
   });
 });

--- a/src/components/inputs/ui-select-extended/ui-select-extended.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.tsx
@@ -38,7 +38,7 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
         ? question.questionOptions.datasource?.config
         : getControlTemplate(question.questionOptions.rendering)?.datasource?.config,
     );
-    getRegisteredDataSource(datasourceName ? datasourceName : question.questionOptions.rendering).then(ds =>
+    getRegisteredDataSource(datasourceName ? datasourceName : question.questionOptions.rendering).then((ds) =>
       setDataSource(ds),
     );
   }, [question.questionOptions?.datasource]);
@@ -50,7 +50,7 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
     }
   }, [question['submission']]);
 
-  const handleChange = value => {
+  const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
     question.value = handler?.handleFieldSubmission(question, value, encounterContext);
@@ -58,7 +58,7 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
 
   const debouncedSearch = debounce((searchterm, dataSource) => {
     setIsLoading(true);
-    dataSource.fetchData(searchterm, config).then(dataItems => {
+    dataSource.fetchData(searchterm, config).then((dataItems) => {
       setItems(dataItems.map(dataSource.toUuidAndDisplay));
       setIsLoading(false);
     });
@@ -68,21 +68,21 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
     // If not searchable, preload the items
     if (dataSource && !isTrue(question.questionOptions.isSearchable)) {
       setIsLoading(true);
-      dataSource.fetchData(null, config).then(dataItems => {
+      dataSource.fetchData(null, config).then((dataItems) => {
         setItems(dataItems.map(dataSource.toUuidAndDisplay));
         setIsLoading(false);
       });
     }
-  }, [dataSource]);
+  }, [dataSource, config]);
 
   useEffect(() => {
     if (dataSource && isTrue(question.questionOptions.isSearchable) && !isEmpty(searchTerm)) {
       debouncedSearch(searchTerm, dataSource);
     }
-  }, [dataSource, searchTerm]);
+  }, [dataSource, searchTerm, config]);
 
   useEffect(() => {
-    getConceptNameAndUUID(question.questionOptions.concept).then(conceptTooltip => {
+    getConceptNameAndUUID(question.questionOptions.concept).then((conceptTooltip) => {
       setConceptName(conceptTooltip);
     });
   }, [conceptName]);
@@ -102,7 +102,7 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
         label={question.label}
         value={
           field.value
-            ? handler?.getDisplayValue(question, items.find(item => item.uuid == field.value)?.display)
+            ? handler?.getDisplayValue(question, items.find((item) => item.uuid == field.value)?.display)
             : field.value
         }
         conceptName={conceptName}
@@ -123,8 +123,8 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
               id={question.id}
               titleText={question.label}
               items={items}
-              itemToString={item => item?.display}
-              selectedItem={items.find(item => item.uuid == field.value)}
+              itemToString={(item) => item?.display}
+              selectedItem={items.find((item) => item.uuid == field.value)}
               shouldFilterItem={({ item, inputValue }) => {
                 if (!inputValue) {
                   // Carbon's initial call at component mount
@@ -138,7 +138,7 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
               }}
               disabled={question.disabled}
               readOnly={question.readonly}
-              onInputChange={value => {
+              onInputChange={(value) => {
                 if (isProcessingSelection.current) {
                   // Notes:
                   // When the user selects a value, both the onChange and onInputChange functions are invoked sequentially.
@@ -157,7 +157,7 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
             <div>
               <PreviousValueReview
                 value={previousValueForReview.value}
-                displayText={items.find(item => item.uuid == previousValueForReview.value)?.display}
+                displayText={items.find((item) => item.uuid == previousValueForReview.value)?.display}
                 setValue={handleChange}
               />
             </div>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
There was an issue where if a datasource had a config, the config would be loaded fine on page load but if there was any attempt to reload the component, the config value would disappear. This PR fixes the issue

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
