### PR TITLE
fix UI-select-extended searchable issues

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -267,7 +267,7 @@ export interface DataSource<T> {
   /**
    * Fetches arbitrary data from a data source
    */
-  fetchData(searchTerm?: string, config?: Record<string, any>): Promise<Array<T>>;
+  fetchData(searchTerm?: string, config?: Record<string, any>, uuid?: string): Promise<Array<T>>;
   /**
    * Maps a data source item to an object with a uuid and display property
    */

--- a/src/components/inputs/ui-select-extended/ui-select-extended.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.tsx
@@ -30,8 +30,12 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
   const isProcessingSelection = useRef(false);
   const [dataSource, setDataSource] = useState(null);
   const [config, setConfig] = useState({});
-  const [savedSearchableItemDisplay, setSavedSearchableItemDisplay] = useState('');
   const [savedSearchableItem, setSavedSearchableItem] = useState({});
+
+  interface DisplayableItem {
+    uuid: string;
+    display: string;
+  }
 
   useEffect(() => {
     const datasourceName = question.questionOptions?.datasource?.name;
@@ -71,7 +75,6 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
   const processSearchableValues = (value) => {
     dataSource.fetchData(null, config, value).then((dataItem) => {
       setSavedSearchableItem(dataItem);
-      setSavedSearchableItemDisplay(dataItem.display);
       setIsLoading(false);
     });
   };
@@ -99,7 +102,7 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
       isTrue(question.questionOptions.isSearchable) &&
       isEmpty(searchTerm) &&
       field.value &&
-      !savedSearchableItemDisplay
+      !Object.keys(savedSearchableItem).length
     ) {
       setIsLoading(true);
       processSearchableValues(field.value);
@@ -152,7 +155,11 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
               titleText={question.label}
               items={items}
               itemToString={(item) => item?.display}
-              selectedItem={items.find((item) => item.uuid == field.value) || savedSearchableItem}
+              selectedItem={
+                encounterContext.sessionMode === 'enter'
+                  ? items.find((item) => item.uuid == field.value)
+                  : items.find((item) => item.uuid == field.value) || savedSearchableItem
+              }
               shouldFilterItem={({ item, inputValue }) => {
                 if (!inputValue) {
                   // Carbon's initial call at component mount
@@ -186,7 +193,8 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
               <PreviousValueReview
                 value={previousValueForReview.value}
                 displayText={
-                  items.find((item) => item.uuid == previousValueForReview.value)?.display || savedSearchableItemDisplay
+                  items.find((item) => item.uuid == previousValueForReview.value)?.display ||
+                  (savedSearchableItem as DisplayableItem).display
                 }
                 setValue={handleChange}
               />

--- a/src/datasources/concept-data-source.ts
+++ b/src/datasources/concept-data-source.ts
@@ -6,20 +6,21 @@ export class ConceptDataSource extends BaseOpenMRSDataSource {
     super('/ws/rest/v1/concept?name=&searchType=fuzzy&v=custom:(uuid,display,conceptClass:(uuid,display))');
   }
 
-  fetchData(searchTerm: string, config?: Record<string, any>): Promise<any[]> {
+  fetchData(searchTerm: string, config?: Record<string, any>, uuid?: string): Promise<any[]> {
+    let apiUrl = this.url;
     if (config?.class) {
       if (typeof config.class == 'string') {
-        let urlParts = this.url.split('name=');
-        this.url = `${urlParts[0]}&name=&class=${config.class}&${urlParts[1]}`;
+        let urlParts = apiUrl.split('name=');
+        apiUrl = `${urlParts[0]}&name=&class=${config.class}&${urlParts[1]}`;
       } else {
-        return openmrsFetch(searchTerm ? `${this.url}&q=${searchTerm}` : this.url).then(({ data }) => {
+        return openmrsFetch(searchTerm ? `${apiUrl}&q=${searchTerm}` : apiUrl).then(({ data }) => {
           return data.results.filter(
             concept => concept.conceptClass && config.class.includes(concept.conceptClass.uuid),
           );
         });
       }
     }
-    return openmrsFetch(searchTerm ? `${this.url}&q=${searchTerm}` : this.url).then(({ data }) => {
+    return openmrsFetch(searchTerm ? `${apiUrl}&q=${searchTerm}` : apiUrl).then(({ data }) => {
       return data.results;
     });
   }

--- a/src/datasources/location-data-source.ts
+++ b/src/datasources/location-data-source.ts
@@ -6,13 +6,22 @@ export class LocationDataSource extends BaseOpenMRSDataSource {
     super('/ws/rest/v1/location?v=custom:(uuid,display)');
   }
 
-  fetchData(searchTerm: string, config?: Record<string, any>): Promise<any[]> {
-    if (config?.tag) {
-      let urlParts = this.url.split('?');
-      this.url = `${urlParts[0]}?tag=${config.tag}&${urlParts[1]}`;
+  fetchData(searchTerm: string, config?: Record<string, any>, uuid?: string): Promise<any[]> {
+    let apiUrl = this.url;
+    const urlParts = apiUrl.split('?');
+    if (config?.tag) {  
+      apiUrl = `${urlParts[0]}?tag=${config.tag}&${urlParts[1]}`;
     }
-    return openmrsFetch(searchTerm ? `${this.url}&q=${searchTerm}` : this.url).then(({ data }) => {
-      return data.results;
+    //overwrite url if there's a uuid value, meaning we are in edit mode
+    if(uuid){
+      apiUrl = `${urlParts[0]}/${uuid}?${urlParts[1]}`;
+    }
+
+    return openmrsFetch(searchTerm ? `${apiUrl}&q=${searchTerm}` : apiUrl).then(({ data }) => {
+      if(data.results){
+        return data.results;
+      }
+      return data;
     });
   }
 }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The UI-select-extended control has 2 flavours:
`Preloaded`(default): Where the data source is loaded on page load and you just search through the items.
`Searchable`: Data source is not pre loaded but as you type, a request is made to the endpoint to return results matching the search criteria.
There were bugs for the `searchable` flavours, i.e in edit mode, it would not pick the saved value. Also in enter mode, it would not show the option for reusing previous value. 
This PR seeks to resolve the issues above

## Screenshots

https://github.com/openmrs/openmrs-form-engine-lib/assets/12844964/5b855d7f-0bd6-42a1-9633-3cfd2fc89539

<img width="656" alt="Screenshot 2024-02-01 at 13 56 35" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/12844964/11e43b5b-33e9-4942-bb0b-c0d460d0c30a">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
