### PR TITLE
(feat) Introducing widget-embedded view mode

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -179,7 +179,7 @@ export interface OHRIFormQuestionOptions {
   isSearchable?: boolean;
 }
 
-export type SessionMode = 'edit' | 'enter' | 'view';
+export type SessionMode = 'edit' | 'enter' | 'view' | 'embedded-view';
 
 export type RenderType =
   | 'select'

--- a/src/components/inputs/content-switcher/ohri-content-switcher.component.tsx
+++ b/src/components/inputs/content-switcher/ohri-content-switcher.component.tsx
@@ -38,11 +38,7 @@ export const OHRIContentSwitcher: React.FC<OHRIFormFieldProps> = ({ question, on
   }, [conceptName, question.questionOptions.concept]);
 
   const isInline = useMemo(() => {
-    if (
-      encounterContext.sessionMode == 'view' ||
-      encounterContext.sessionMode == 'embedded-view' ||
-      isTrue(question.readonly)
-    ) {
+    if (['view', 'embedded-view'].includes(encounterContext.sessionMode) || isTrue(question.readonly)) {
       return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;

--- a/src/components/inputs/content-switcher/ohri-content-switcher.component.tsx
+++ b/src/components/inputs/content-switcher/ohri-content-switcher.component.tsx
@@ -20,31 +20,37 @@ export const OHRIContentSwitcher: React.FC<OHRIFormFieldProps> = ({ question, on
     }
   }, [question]);
 
-  const handleChange = value => {
+  const handleChange = (value) => {
     setFieldValue(question.id, value?.name);
     onChange(question.id, value?.name, setErrors, null);
     question.value = handler?.handleFieldSubmission(question, value?.name, encounterContext);
   };
 
   const selectedIndex = useMemo(
-    () => question.questionOptions.answers.findIndex(option => option.concept == field.value),
+    () => question.questionOptions.answers.findIndex((option) => option.concept == field.value),
     [field.value, question.questionOptions.answers],
   );
 
   useEffect(() => {
-    getConceptNameAndUUID(question.questionOptions.concept).then(conceptTooltip => {
+    getConceptNameAndUUID(question.questionOptions.concept).then((conceptTooltip) => {
       setConceptName(conceptTooltip);
     });
   }, [conceptName, question.questionOptions.concept]);
 
   const isInline = useMemo(() => {
-    if (encounterContext.sessionMode == 'view' || isTrue(question.readonly)) {
-      return isInlineView(question.inlineRendering, layoutType, workspaceLayout);
+    if (
+      encounterContext.sessionMode == 'view' ||
+      encounterContext.sessionMode == 'embedded-view' ||
+      isTrue(question.readonly)
+    ) {
+      return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
+  return encounterContext.sessionMode == 'view' ||
+    encounterContext.sessionMode == 'embedded-view' ||
+    isTrue(question.readonly) ? (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}

--- a/src/components/inputs/date/ohri-date.component.tsx
+++ b/src/components/inputs/date/ohri-date.component.tsx
@@ -33,8 +33,12 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
   }, [question['submission']]);
 
   const isInline = useMemo(() => {
-    if (encounterContext.sessionMode == 'view' || isTrue(question.readonly)) {
-      return isInlineView(question.inlineRendering, layoutType, workspaceLayout);
+    if (
+      encounterContext.sessionMode == 'view' ||
+      encounterContext.sessionMode == 'embedded-view' ||
+      isTrue(question.readonly)
+    ) {
+      return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
@@ -67,7 +71,7 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
   const { placeholder, carbonDateformat } = useMemo(() => {
     const formatObj = dateFormatter.formatToParts(new Date());
     const placeholder = formatObj
-      .map(obj => {
+      .map((obj) => {
         switch (obj.type) {
           case 'day':
             return 'dd';
@@ -81,7 +85,7 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
       })
       .join('');
     const carbonDateformat = formatObj
-      .map(obj => {
+      .map((obj) => {
         switch (obj.type) {
           case 'day':
             return 'd';
@@ -119,7 +123,7 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
   }, [encounterContext?.previousEncounter]);
 
   useEffect(() => {
-    getConceptNameAndUUID(question.questionOptions.concept).then(conceptTooltip => {
+    getConceptNameAndUUID(question.questionOptions.concept).then((conceptTooltip) => {
       setConceptName(conceptTooltip);
     });
   }, [conceptName]);
@@ -134,7 +138,7 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
     }
   }, [field.value, time]);
 
-  return encounterContext.sessionMode == 'view' ? (
+  return encounterContext.sessionMode == 'view' || encounterContext.sessionMode == 'embedded-view' ? (
     <OHRIFieldValueView
       label={question.label}
       value={field.value instanceof Date ? getDisplay(field.value, question.questionOptions.rendering) : field.value}
@@ -164,7 +168,7 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
                 // Something strange is happening with the way events are propagated and handled by Carbon.
                 // When we manually trigger an onchange event using the 'fireEvent' lib, the handler below will
                 // be triggered as opposed to the former handler that only gets triggered at runtime.
-                onChange={e => onDateChange([dayjs(e.target.value, placeholder.toUpperCase()).toDate()])}
+                onChange={(e) => onDateChange([dayjs(e.target.value, placeholder.toUpperCase()).toDate()])}
                 disabled={question.disabled}
                 invalid={!isFieldRequiredError && errors.length > 0}
                 invalidText={errors[0]?.message}

--- a/src/components/inputs/date/ohri-date.component.tsx
+++ b/src/components/inputs/date/ohri-date.component.tsx
@@ -33,11 +33,7 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
   }, [question['submission']]);
 
   const isInline = useMemo(() => {
-    if (
-      encounterContext.sessionMode == 'view' ||
-      encounterContext.sessionMode == 'embedded-view' ||
-      isTrue(question.readonly)
-    ) {
+    if (['view', 'embedded-view'].includes(encounterContext.sessionMode) || isTrue(question.readonly)) {
       return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;

--- a/src/components/inputs/file/file.component.tsx
+++ b/src/components/inputs/file/file.component.tsx
@@ -49,11 +49,7 @@ const File: React.FC<FileProps> = ({ question, onChange, handler }) => {
   }, [myInitVal]);
 
   const isInline = useMemo(() => {
-    if (
-      encounterContext.sessionMode == 'view' ||
-      encounterContext.sessionMode == 'embedded-view' ||
-      isTrue(question.readonly)
-    ) {
+    if (['view', 'embedded-view'].includes(encounterContext.sessionMode) || isTrue(question.readonly)) {
       return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;

--- a/src/components/inputs/file/file.component.tsx
+++ b/src/components/inputs/file/file.component.tsx
@@ -49,8 +49,12 @@ const File: React.FC<FileProps> = ({ question, onChange, handler }) => {
   }, [myInitVal]);
 
   const isInline = useMemo(() => {
-    if (encounterContext.sessionMode == 'view' || isTrue(question.readonly)) {
-      return isInlineView(question.inlineRendering, layoutType, workspaceLayout);
+    if (
+      encounterContext.sessionMode == 'view' ||
+      encounterContext.sessionMode == 'embedded-view' ||
+      isTrue(question.readonly)
+    ) {
+      return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);

--- a/src/components/inputs/location/ohri-encounter-location.component.tsx
+++ b/src/components/inputs/location/ohri-encounter-location.component.tsx
@@ -27,11 +27,7 @@ export const OHRIEncounterLocationPicker: React.FC<{ question: OHRIFormField; on
   }, []);
 
   const isInline = useMemo(() => {
-    if (
-      encounterContext.sessionMode == 'view' ||
-      encounterContext.sessionMode == 'embedded-view' ||
-      isTrue(question.readonly)
-    ) {
+    if (['view', 'embedded-view'].includes(encounterContext.sessionMode) || isTrue(question.readonly)) {
       return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;

--- a/src/components/inputs/multi-select/ohri-multi-select.component.tsx
+++ b/src/components/inputs/multi-select/ohri-multi-select.component.tsx
@@ -72,11 +72,7 @@ export const OHRIMultiSelect: React.FC<OHRIFormFieldProps> = ({ question, onChan
   }, [conceptName]);
 
   const isInline = useMemo(() => {
-    if (
-      encounterContext.sessionMode == 'view' ||
-      encounterContext.sessionMode == 'embedded-view' ||
-      isTrue(question.readonly)
-    ) {
+    if (['view', 'embedded-view'].includes(encounterContext.sessionMode) || isTrue(question.readonly)) {
       return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;

--- a/src/components/inputs/multi-select/ohri-multi-select.component.tsx
+++ b/src/components/inputs/multi-select/ohri-multi-select.component.tsx
@@ -42,7 +42,7 @@ export const OHRIMultiSelect: React.FC<OHRIFormFieldProps> = ({ question, onChan
   }, [question['submission']]);
 
   const questionItems = question.questionOptions.answers
-    .filter(answer => !answer.isHidden)
+    .filter((answer) => !answer.isHidden)
     .map((answer, index) => ({
       id: `${question.id}-${answer.concept}`,
       concept: answer.concept,
@@ -51,7 +51,7 @@ export const OHRIMultiSelect: React.FC<OHRIFormFieldProps> = ({ question, onChan
     }));
 
   const initiallySelectedQuestionItems = [];
-  questionItems.forEach(item => {
+  questionItems.forEach((item) => {
     if (field.value?.includes(item.concept)) {
       initiallySelectedQuestionItems.push(item);
     }
@@ -59,26 +59,30 @@ export const OHRIMultiSelect: React.FC<OHRIFormFieldProps> = ({ question, onChan
 
   const handleSelectItemsChange = ({ selectedItems }) => {
     setTouched(true);
-    const value = selectedItems.map(selectedItem => selectedItem.concept);
+    const value = selectedItems.map((selectedItem) => selectedItem.concept);
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
     question.value = handler?.handleFieldSubmission(question, value, encounterContext);
   };
 
   useEffect(() => {
-    getConceptNameAndUUID(question.questionOptions.concept).then(conceptTooltip => {
+    getConceptNameAndUUID(question.questionOptions.concept).then((conceptTooltip) => {
       setConceptName(conceptTooltip);
     });
   }, [conceptName]);
 
   const isInline = useMemo(() => {
-    if (encounterContext.sessionMode == 'view' || isTrue(question.readonly)) {
-      return isInlineView(question.inlineRendering, layoutType, workspaceLayout);
+    if (
+      encounterContext.sessionMode == 'view' ||
+      encounterContext.sessionMode == 'embedded-view' ||
+      isTrue(question.readonly)
+    ) {
+      return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' ? (
+  return encounterContext.sessionMode == 'view' || encounterContext.sessionMode == 'embedded-view' ? (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}
@@ -105,7 +109,7 @@ export const OHRIMultiSelect: React.FC<OHRIFormFieldProps> = ({ question, onChan
             label={''}
             titleText={question.label}
             key={counter}
-            itemToString={item => (item ? item.label : ' ')}
+            itemToString={(item) => (item ? item.label : ' ')}
             disabled={question.disabled}
             invalid={!isFieldRequiredError && errors.length > 0}
             invalidText={errors[0]?.message}
@@ -117,7 +121,7 @@ export const OHRIMultiSelect: React.FC<OHRIFormFieldProps> = ({ question, onChan
         <div className={styles.formField} style={{ marginTop: '0.125rem' }}>
           {field.value?.length ? (
             <UnorderedList className={styles.list}>
-              {handler?.getDisplayValue(question, field.value)?.map(displayValue => displayValue + ', ')}
+              {handler?.getDisplayValue(question, field.value)?.map((displayValue) => displayValue + ', ')}
             </UnorderedList>
           ) : (
             <OHRIValueEmpty />

--- a/src/components/inputs/number/ohri-number.component.tsx
+++ b/src/components/inputs/number/ohri-number.component.tsx
@@ -27,7 +27,7 @@ const OHRINumber: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
     }
   }, [question['submission']]);
 
-  field.onBlur = event => {
+  field.onBlur = (event) => {
     if (event && event.target.value != field.value) {
       // testing purposes only
       field.value = event.target.value;
@@ -58,19 +58,23 @@ const OHRINumber: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
   }, [encounterContext?.previousEncounter]);
 
   useEffect(() => {
-    getConceptNameAndUUID(question.questionOptions.concept).then(conceptTooltip => {
+    getConceptNameAndUUID(question.questionOptions.concept).then((conceptTooltip) => {
       setConceptName(conceptTooltip);
     });
   }, [conceptName]);
 
   const isInline = useMemo(() => {
-    if (encounterContext.sessionMode == 'view' || isTrue(question.readonly)) {
-      return isInlineView(question.inlineRendering, layoutType, workspaceLayout);
+    if (
+      encounterContext.sessionMode == 'view' ||
+      encounterContext.sessionMode == 'embedded-view' ||
+      isTrue(question.readonly)
+    ) {
+      return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' ? (
+  return encounterContext.sessionMode == 'view' || encounterContext.sessionMode == 'embedded-view' ? (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}
@@ -97,7 +101,7 @@ const OHRINumber: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
             allowEmpty={true}
             size="lg"
             hideSteppers={true}
-            onWheel={e => e.target.blur()}
+            onWheel={(e) => e.target.blur()}
             disabled={question.disabled}
             readOnly={question.readonly}
             className={isFieldRequiredError ? styles.errorLabel : ''}

--- a/src/components/inputs/number/ohri-number.component.tsx
+++ b/src/components/inputs/number/ohri-number.component.tsx
@@ -64,11 +64,7 @@ const OHRINumber: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
   }, [conceptName]);
 
   const isInline = useMemo(() => {
-    if (
-      encounterContext.sessionMode == 'view' ||
-      encounterContext.sessionMode == 'embedded-view' ||
-      isTrue(question.readonly)
-    ) {
+    if (['view', 'embedded-view'].includes(encounterContext.sessionMode) || isTrue(question.readonly)) {
       return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;

--- a/src/components/inputs/radio/ohri-radio.component.tsx
+++ b/src/components/inputs/radio/ohri-radio.component.tsx
@@ -50,11 +50,7 @@ const OHRIRadio: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }
   }, [encounterContext?.previousEncounter]);
 
   const isInline = useMemo(() => {
-    if (
-      encounterContext.sessionMode == 'view' ||
-      encounterContext.sessionMode == 'embedded-view' ||
-      isTrue(question.readonly)
-    ) {
+    if (['view', 'embedded-view'].includes(encounterContext.sessionMode) || isTrue(question.readonly)) {
       return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;

--- a/src/components/inputs/radio/ohri-radio.component.tsx
+++ b/src/components/inputs/radio/ohri-radio.component.tsx
@@ -27,14 +27,14 @@ const OHRIRadio: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }
     }
   }, [question['submission']]);
 
-  const handleChange = value => {
+  const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
     question.value = handler?.handleFieldSubmission(question, value, encounterContext);
   };
 
   useEffect(() => {
-    getConceptNameAndUUID(question.questionOptions.concept).then(conceptTooltip => {
+    getConceptNameAndUUID(question.questionOptions.concept).then((conceptTooltip) => {
       setConceptName(conceptTooltip);
     });
   }, [conceptName]);
@@ -50,13 +50,19 @@ const OHRIRadio: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }
   }, [encounterContext?.previousEncounter]);
 
   const isInline = useMemo(() => {
-    if (encounterContext.sessionMode == 'view' || isTrue(question.readonly)) {
-      return isInlineView(question.inlineRendering, layoutType, workspaceLayout);
+    if (
+      encounterContext.sessionMode == 'view' ||
+      encounterContext.sessionMode == 'embedded-view' ||
+      isTrue(question.readonly)
+    ) {
+      return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
+  return encounterContext.sessionMode == 'view' ||
+    encounterContext.sessionMode == 'embedded-view' ||
+    isTrue(question.readonly) ? (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}
@@ -80,7 +86,7 @@ const OHRIRadio: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler }
             onChange={handleChange}
             orientation="vertical">
             {question.questionOptions.answers
-              .filter(answer => !answer.isHidden)
+              .filter((answer) => !answer.isHidden)
               .map((answer, index) => {
                 return (
                   <RadioButton

--- a/src/components/inputs/select/ohri-dropdown.component.tsx
+++ b/src/components/inputs/select/ohri-dropdown.component.tsx
@@ -27,24 +27,26 @@ const OHRIDropdown: React.FC<OHRIFormFieldProps> = ({ question, onChange, handle
     }
   }, [question['submission']]);
 
-  const handleChange = value => {
+  const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
     question.value = handler?.handleFieldSubmission(question, value, encounterContext);
   };
 
-  const itemToString = item => {
-    const answer = question.questionOptions.answers.find(opt => (opt.value ? opt.value == item : opt.concept == item));
+  const itemToString = (item) => {
+    const answer = question.questionOptions.answers.find((opt) =>
+      opt.value ? opt.value == item : opt.concept == item,
+    );
     return answer?.label;
   };
   useEffect(() => {
     setItems(
-      question.questionOptions.answers.filter(answer => !answer.isHidden).map(item => item.value || item.concept),
+      question.questionOptions.answers.filter((answer) => !answer.isHidden).map((item) => item.value || item.concept),
     );
   }, [question.questionOptions.answers]);
 
   useEffect(() => {
-    getConceptNameAndUUID(question.questionOptions.concept).then(conceptTooltip => {
+    getConceptNameAndUUID(question.questionOptions.concept).then((conceptTooltip) => {
       setConceptName(conceptTooltip);
     });
   }, [conceptName]);
@@ -59,13 +61,17 @@ const OHRIDropdown: React.FC<OHRIFormFieldProps> = ({ question, onChange, handle
   }, [encounterContext?.previousEncounter]);
 
   const isInline = useMemo(() => {
-    if (encounterContext.sessionMode == 'view' || isTrue(question.readonly)) {
-      return isInlineView(question.inlineRendering, layoutType, workspaceLayout);
+    if (
+      encounterContext.sessionMode == 'view' ||
+      encounterContext.sessionMode == 'embedded-view' ||
+      isTrue(question.readonly)
+    ) {
+      return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' ? (
+  return encounterContext.sessionMode == 'view' || encounterContext.sessionMode == 'embedded-view' ? (
     <OHRIFieldValueView
       label={question.label}
       value={field.value ? handler?.getDisplayValue(question, field.value) : field.value}
@@ -81,8 +87,8 @@ const OHRIDropdown: React.FC<OHRIFormFieldProps> = ({ question, onChange, handle
             titleText={question.label}
             label="Choose an option"
             items={question.questionOptions.answers
-              .filter(answer => !answer.isHidden)
-              .map(item => item.value || item.concept)}
+              .filter((answer) => !answer.isHidden)
+              .map((item) => item.value || item.concept)}
             itemToString={itemToString}
             selectedItem={field.value}
             onChange={({ selectedItem }) => handleChange(selectedItem)}

--- a/src/components/inputs/select/ohri-dropdown.component.tsx
+++ b/src/components/inputs/select/ohri-dropdown.component.tsx
@@ -61,11 +61,7 @@ const OHRIDropdown: React.FC<OHRIFormFieldProps> = ({ question, onChange, handle
   }, [encounterContext?.previousEncounter]);
 
   const isInline = useMemo(() => {
-    if (
-      encounterContext.sessionMode == 'view' ||
-      encounterContext.sessionMode == 'embedded-view' ||
-      isTrue(question.readonly)
-    ) {
+    if (['view', 'embedded-view'].includes(encounterContext.sessionMode) || isTrue(question.readonly)) {
       return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;

--- a/src/components/inputs/text-area/ohri-text-area.component.tsx
+++ b/src/components/inputs/text-area/ohri-text-area.component.tsx
@@ -36,19 +36,23 @@ const OHRITextArea: React.FC<OHRIFormFieldProps> = ({ question, onChange, handle
   };
 
   useEffect(() => {
-    getConceptNameAndUUID(question.questionOptions.concept).then(conceptTooltip => {
+    getConceptNameAndUUID(question.questionOptions.concept).then((conceptTooltip) => {
       setConceptName(conceptTooltip);
     });
   }, [conceptName]);
 
   const isInline = useMemo(() => {
-    if (encounterContext.sessionMode == 'view' || isTrue(question.readonly)) {
-      return isInlineView(question.inlineRendering, layoutType, workspaceLayout);
+    if (
+      encounterContext.sessionMode == 'view' ||
+      encounterContext.sessionMode == 'embedded-view' ||
+      isTrue(question.readonly)
+    ) {
+      return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' ? (
+  return encounterContext.sessionMode == 'view' || encounterContext.sessionMode == 'embedded-view' ? (
     <div className={styles.formField}>
       <OHRIFieldValueView label={question.label} value={field.value} conceptName={conceptName} isInline={isInline} />
     </div>

--- a/src/components/inputs/text-area/ohri-text-area.component.tsx
+++ b/src/components/inputs/text-area/ohri-text-area.component.tsx
@@ -42,11 +42,7 @@ const OHRITextArea: React.FC<OHRIFormFieldProps> = ({ question, onChange, handle
   }, [conceptName]);
 
   const isInline = useMemo(() => {
-    if (
-      encounterContext.sessionMode == 'view' ||
-      encounterContext.sessionMode == 'embedded-view' ||
-      isTrue(question.readonly)
-    ) {
+    if (['view', 'embedded-view'].includes(encounterContext.sessionMode) || isTrue(question.readonly)) {
       return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;

--- a/src/components/inputs/text/ohri-text.component.tsx
+++ b/src/components/inputs/text/ohri-text.component.tsx
@@ -60,11 +60,7 @@ const OHRIText: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
   }, [conceptName]);
 
   const isInline = useMemo(() => {
-    if (
-      encounterContext.sessionMode == 'view' ||
-      encounterContext.sessionMode == 'embedded-view' ||
-      isTrue(question.readonly)
-    ) {
+    if (['view', 'embedded-view'].includes(encounterContext.sessionMode) || isTrue(question.readonly)) {
       return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;

--- a/src/components/inputs/text/ohri-text.component.tsx
+++ b/src/components/inputs/text/ohri-text.component.tsx
@@ -60,13 +60,17 @@ const OHRIText: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler })
   }, [conceptName]);
 
   const isInline = useMemo(() => {
-    if (encounterContext.sessionMode == 'view' || isTrue(question.readonly)) {
-      return isInlineView(question.inlineRendering, layoutType, workspaceLayout);
+    if (
+      encounterContext.sessionMode == 'view' ||
+      encounterContext.sessionMode == 'embedded-view' ||
+      isTrue(question.readonly)
+    ) {
+      return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' ? (
+  return encounterContext.sessionMode == 'view' || encounterContext.sessionMode == 'embedded-view' ? (
     <div className={styles.formField}>
       <OHRIFieldValueView label={question.label} value={field.value} conceptName={conceptName} isInline={isInline} />
     </div>

--- a/src/components/inputs/toggle/ohri-toggle.component.tsx
+++ b/src/components/inputs/toggle/ohri-toggle.component.tsx
@@ -13,7 +13,7 @@ const OHRIToggle: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
   const [field, meta] = useField(question.id);
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(OHRIFormContext);
   const [conceptName, setConceptName] = useState('Loading...');
-  const handleChange = value => {
+  const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, null, null);
     question.value = handler?.handleFieldSubmission(question, value, encounterContext);
@@ -28,19 +28,23 @@ const OHRIToggle: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
   }, []);
 
   useEffect(() => {
-    getConceptNameAndUUID(question.questionOptions.concept).then(conceptTooltip => {
+    getConceptNameAndUUID(question.questionOptions.concept).then((conceptTooltip) => {
       setConceptName(conceptTooltip);
     });
   }, [conceptName]);
 
   const isInline = useMemo(() => {
-    if (encounterContext.sessionMode == 'view' || isTrue(question.readonly)) {
-      return isInlineView(question.inlineRendering, layoutType, workspaceLayout);
+    if (
+      encounterContext.sessionMode == 'view' ||
+      encounterContext.sessionMode == 'embedded-view' ||
+      isTrue(question.readonly)
+    ) {
+      return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
-  return encounterContext.sessionMode == 'view' ? (
+  return encounterContext.sessionMode == 'view' || encounterContext.sessionMode == 'embedded-view' ? (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}

--- a/src/components/inputs/toggle/ohri-toggle.component.tsx
+++ b/src/components/inputs/toggle/ohri-toggle.component.tsx
@@ -34,11 +34,7 @@ const OHRIToggle: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
   }, [conceptName]);
 
   const isInline = useMemo(() => {
-    if (
-      encounterContext.sessionMode == 'view' ||
-      encounterContext.sessionMode == 'embedded-view' ||
-      isTrue(question.readonly)
-    ) {
+    if (['view', 'embedded-view'].includes(encounterContext.sessionMode) || isTrue(question.readonly)) {
       return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;

--- a/src/components/inputs/ui-select-extended/ui-select-extended.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.tsx
@@ -38,11 +38,7 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
   }
 
   const isInline = useMemo(() => {
-    if (
-      encounterContext.sessionMode == 'view' ||
-      encounterContext.sessionMode == 'embedded-view' ||
-      isTrue(question.readonly)
-    ) {
+    if (['view', 'embedded-view'].includes(encounterContext.sessionMode) || isTrue(question.readonly)) {
       return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
     }
     return false;

--- a/src/components/inputs/ui-select-extended/ui-select-extended.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.tsx
@@ -4,7 +4,7 @@ import { OHRIFormFieldProps } from '../../../api/types';
 import { useField } from 'formik';
 import styles from './ui-select-extended.scss';
 import { OHRIFormContext } from '../../../ohri-form-context';
-import { getConceptNameAndUUID } from '../../../utils/ohri-form-helper';
+import { getConceptNameAndUUID, isInlineView } from '../../../utils/ohri-form-helper';
 import { OHRIFieldValueView } from '../../value/view/ohri-field-value-view.component';
 import { isTrue } from '../../../utils/boolean-utils';
 import { fieldRequiredErrCode, isEmpty } from '../../../validators/ohri-form-validator';
@@ -17,7 +17,7 @@ import { getControlTemplate } from '../../../registry/inbuilt-components/control
 const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onChange }) => {
   const { t } = useTranslation();
   const [field, meta] = useField(question.id);
-  const { setFieldValue, encounterContext, fields } = React.useContext(OHRIFormContext);
+  const { setFieldValue, encounterContext, layoutType, workspaceLayout, fields } = React.useContext(OHRIFormContext);
   const [conceptName, setConceptName] = useState('Loading...');
   const [items, setItems] = useState([]);
   const [warnings, setWarnings] = useState([]);
@@ -36,6 +36,17 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
     uuid: string;
     display: string;
   }
+
+  const isInline = useMemo(() => {
+    if (
+      encounterContext.sessionMode == 'view' ||
+      encounterContext.sessionMode == 'embedded-view' ||
+      isTrue(question.readonly)
+    ) {
+      return isInlineView(question.inlineRendering, layoutType, workspaceLayout, encounterContext.sessionMode);
+    }
+    return false;
+  }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
   useEffect(() => {
     const datasourceName = question.questionOptions?.datasource?.name;
@@ -127,7 +138,9 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
     }
   }, [encounterContext?.previousEncounter]);
 
-  return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
+  return encounterContext.sessionMode == 'view' ||
+    encounterContext.sessionMode == 'embedded-view' ||
+    isTrue(question.readonly) ? (
     <div className={styles.formField}>
       <OHRIFieldValueView
         label={question.label}
@@ -137,7 +150,7 @@ const UISelectExtended: React.FC<OHRIFormFieldProps> = ({ question, handler, onC
             : field.value
         }
         conceptName={conceptName}
-        isInline
+        isInline={isInline}
       />
     </div>
   ) : (

--- a/src/components/label/ohri-label.component.tsx
+++ b/src/components/label/ohri-label.component.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { DefinitionTooltip } from '@carbon/react';
 import styles from './ohri-label.scss';
 
 type LabelProps = {
@@ -10,9 +9,7 @@ type LabelProps = {
 export const OHRILabel: React.FC<LabelProps> = ({ value, tooltipText }) => {
   return (
     <div className={styles.label}>
-      <DefinitionTooltip direction="bottom" tabIndex={0} tooltipText={tooltipText}>
-        <span className="cds--label">{value}</span>
-      </DefinitionTooltip>
+      <span className="cds--label">{`${value}:`}</span>
     </div>
   );
 };

--- a/src/components/label/ohri-label.scss
+++ b/src/components/label/ohri-label.scss
@@ -1,8 +1,5 @@
 
 .label {
-  // width: auto !important;
-  // background-color: burlywood;
-  flex-basis: 1;
   :global(.cds--assistive-text) {
     max-width: 30rem !important;
     font-size: 0.75rem;

--- a/src/components/label/ohri-label.scss
+++ b/src/components/label/ohri-label.scss
@@ -1,13 +1,13 @@
 
 .label {
-  width: auto !important;
-
+  // width: auto !important;
+  // background-color: burlywood;
+  flex-basis: 1;
   :global(.cds--assistive-text) {
     max-width: 30rem !important;
     font-size: 0.75rem;
     white-space: pre-line !important;
   }
-
   :global(.cds--label) {
     font-weight: bolder;
   }

--- a/src/components/page/ohri-form-page.scss
+++ b/src/components/page/ohri-form-page.scss
@@ -33,7 +33,10 @@
 }
 
 .formSection {
+  margin: 1rem;
   flex: 1 1 65%;
+  background-color: colors.$gray-10;
+  padding: 1rem;
 }
 
 .formSection > div > fieldset {

--- a/src/components/page/ohri-form-page.scss
+++ b/src/components/page/ohri-form-page.scss
@@ -33,14 +33,18 @@
 }
 
 .formSection {
-  margin: 1rem;
   flex: 1 1 65%;
-  background-color: colors.$gray-10;
-  padding: 1rem;
 }
 
 .formSection > div > fieldset {
   margin-bottom: 0 !important;
+}
+
+.embeddedFormSection{
+  background-color: colors.$gray-10;
+  margin-left: 0.75rem;
+  padding: 0.5rem 0 0.5rem 0.75rem;
+  
 }
 
 .collapseToggle {
@@ -64,4 +68,8 @@
   :global(.cds--accordion__content) {
     padding-right: 2rem !important;
   }
+}
+
+.sectionHeader{
+  font-weight: 700;
 }

--- a/src/components/page/ohri-form-page.tsx
+++ b/src/components/page/ohri-form-page.tsx
@@ -4,36 +4,53 @@ import { Waypoint } from 'react-waypoint';
 import { isTrue } from '../../utils/boolean-utils';
 import OHRIFormSection from '../section/ohri-form-section.component';
 import styles from './ohri-form-page.scss';
+import { OHRIFormContext } from '../../ohri-form-context';
 
 function OHRIFormPage({ page, onFieldChange, setSelectedPage, isFormExpanded }) {
   const trimmedLabel = useMemo(() => page.label.replace(/\s/g, ''), [page.label]);
+  const { encounterContext } = React.useContext(OHRIFormContext);
   const visibleSections = page.sections.filter((section) => {
     const hasVisibleQuestions = section.questions.some((question) => !isTrue(question.isHidden));
     return !isTrue(section.isHidden) && hasVisibleQuestions;
   });
 
-  return (
+  return encounterContext.sessionMode == 'embedded-view' ? (
+    <div>
+      <div className={styles.pageHeader}>
+        <p className={styles.pageTitle}>{page.label}</p>
+      </div>
+      {visibleSections.map((section) => (
+        <div className={styles.embeddedFormSection}>
+          <div className={styles.sectionHeader}>{section.label}</div>
+          <OHRIFormSection
+            fields={section.questions.filter((question) => !isTrue(question.isHidden))}
+            onFieldChange={onFieldChange}
+          />
+        </div>
+      ))}
+    </div>
+  ) : (
     <Waypoint onEnter={() => setSelectedPage(trimmedLabel)} topOffset="50%" bottomOffset="60%">
       <div id={trimmedLabel} className={styles.pageContent}>
         <div className={styles.pageHeader}>
           <p className={styles.pageTitle}>{page.label}</p>
         </div>
-        {/* <Accordion> */}
-        {visibleSections.map((section) => (
-          // <AccordionItem
-          //   title={section.label}
-          //   open={isFormExpanded !== undefined ? isFormExpanded : isTrue(section.isExpanded)}
-          //   className={styles.sectionContent}
-          //   key={`section-${section.id}`}>
-          <div className={styles.formSection}>
-            <OHRIFormSection
-              fields={section.questions.filter((question) => !isTrue(question.isHidden))}
-              onFieldChange={onFieldChange}
-            />
-          </div>
-          // </AccordionItem>
-        ))}
-        {/* </Accordion> */}
+        <Accordion>
+          {visibleSections.map((section) => (
+            <AccordionItem
+              title={section.label}
+              open={isFormExpanded !== undefined ? isFormExpanded : isTrue(section.isExpanded)}
+              className={styles.sectionContent}
+              key={`section-${section.id}`}>
+              <div className={styles.formSection}>
+                <OHRIFormSection
+                  fields={section.questions.filter((question) => !isTrue(question.isHidden))}
+                  onFieldChange={onFieldChange}
+                />
+              </div>
+            </AccordionItem>
+          ))}
+        </Accordion>
       </div>
     </Waypoint>
   );

--- a/src/components/page/ohri-form-page.tsx
+++ b/src/components/page/ohri-form-page.tsx
@@ -7,8 +7,8 @@ import styles from './ohri-form-page.scss';
 
 function OHRIFormPage({ page, onFieldChange, setSelectedPage, isFormExpanded }) {
   const trimmedLabel = useMemo(() => page.label.replace(/\s/g, ''), [page.label]);
-  const visibleSections = page.sections.filter(section => {
-    const hasVisibleQuestions = section.questions.some(question => !isTrue(question.isHidden));
+  const visibleSections = page.sections.filter((section) => {
+    const hasVisibleQuestions = section.questions.some((question) => !isTrue(question.isHidden));
     return !isTrue(section.isHidden) && hasVisibleQuestions;
   });
 
@@ -18,22 +18,22 @@ function OHRIFormPage({ page, onFieldChange, setSelectedPage, isFormExpanded }) 
         <div className={styles.pageHeader}>
           <p className={styles.pageTitle}>{page.label}</p>
         </div>
-        <Accordion>
-          {visibleSections.map(section => (
-            <AccordionItem
-              title={section.label}
-              open={isFormExpanded !== undefined ? isFormExpanded : isTrue(section.isExpanded)}
-              className={styles.sectionContent}
-              key={`section-${section.id}`}>
-              <div className={styles.formSection}>
-                <OHRIFormSection
-                  fields={section.questions.filter(question => !isTrue(question.isHidden))}
-                  onFieldChange={onFieldChange}
-                />
-              </div>
-            </AccordionItem>
-          ))}
-        </Accordion>
+        {/* <Accordion> */}
+        {visibleSections.map((section) => (
+          // <AccordionItem
+          //   title={section.label}
+          //   open={isFormExpanded !== undefined ? isFormExpanded : isTrue(section.isExpanded)}
+          //   className={styles.sectionContent}
+          //   key={`section-${section.id}`}>
+          <div className={styles.formSection}>
+            <OHRIFormSection
+              fields={section.questions.filter((question) => !isTrue(question.isHidden))}
+              onFieldChange={onFieldChange}
+            />
+          </div>
+          // </AccordionItem>
+        ))}
+        {/* </Accordion> */}
       </div>
     </Waypoint>
   );

--- a/src/components/section/ohri-form-section.component.tsx
+++ b/src/components/section/ohri-form-section.component.tsx
@@ -8,8 +8,6 @@ import { OHRIFormField, OHRIFormFieldProps, SubmissionHandler } from '../../api/
 import styles from './ohri-form-section.scss';
 import { getFieldControlWithFallback, isUnspecifiedSupported } from './helpers';
 import { OHRITooltip } from '../inputs/tooltip/ohri-tooltip';
-import { subtle } from 'crypto';
-import { OHRIFormContext } from '../../ohri-form-context';
 
 interface FieldComponentMap {
   fieldComponent: React.ComponentType<OHRIFormFieldProps>;
@@ -19,8 +17,6 @@ interface FieldComponentMap {
 
 const OHRIFormSection = ({ fields, onFieldChange }) => {
   const [fieldComponentMapEntries, setFieldComponentMapEntries] = useState<FieldComponentMap[]>([]);
-  const { encounterContext } = React.useContext(OHRIFormContext);
-  const { sessionMode } = encounterContext;
 
   useEffect(() => {
     Promise.all(

--- a/src/components/section/ohri-form-section.component.tsx
+++ b/src/components/section/ohri-form-section.component.tsx
@@ -9,6 +9,7 @@ import styles from './ohri-form-section.scss';
 import { getFieldControlWithFallback, isUnspecifiedSupported } from './helpers';
 import { OHRITooltip } from '../inputs/tooltip/ohri-tooltip';
 import { subtle } from 'crypto';
+import { OHRIFormContext } from '../../ohri-form-context';
 
 interface FieldComponentMap {
   fieldComponent: React.ComponentType<OHRIFormFieldProps>;
@@ -18,6 +19,8 @@ interface FieldComponentMap {
 
 const OHRIFormSection = ({ fields, onFieldChange }) => {
   const [fieldComponentMapEntries, setFieldComponentMapEntries] = useState<FieldComponentMap[]>([]);
+  const { encounterContext } = React.useContext(OHRIFormContext);
+  const { sessionMode } = encounterContext;
 
   useEffect(() => {
     Promise.all(

--- a/src/components/section/ohri-form-section.scss
+++ b/src/components/section/ohri-form-section.scss
@@ -6,7 +6,7 @@
 }
 
 .parent{
-  width: 360px;
+  // width: 360px;
 }
 
 .tooltipWithUnspecified{

--- a/src/components/section/ohri-form-section.scss
+++ b/src/components/section/ohri-form-section.scss
@@ -6,7 +6,6 @@
 }
 
 .parent{
-  // width: 360px;
 }
 
 .tooltipWithUnspecified{

--- a/src/components/section/ohri-form-section.scss
+++ b/src/components/section/ohri-form-section.scss
@@ -30,7 +30,7 @@
 }
 
 .sectionContainer {
-  margin-top: 1.438rem;
+  margin-top: 1rem;
   width: 90%;
 }
 

--- a/src/components/value/ohri-value.component.tsx
+++ b/src/components/value/ohri-value.component.tsx
@@ -13,13 +13,13 @@ export const OHRIValueDisplay = ({ value }) => {
   if (Array.isArray(value)) {
     return <OHRIListDisplay valueArray={value} />;
   }
-  return <span className={styles.value}>{value}</span>;
+  return <div className={styles.value}>{value}</div>;
 };
 
 const OHRIListDisplay = ({ valueArray }) => {
   return (
     <ul>
-      {valueArray.map(item => (
+      {valueArray.map((item) => (
         <li className={styles.item}>{item}</li>
       ))}
     </ul>

--- a/src/components/value/ohri-value.scss
+++ b/src/components/value/ohri-value.scss
@@ -2,7 +2,7 @@
 
 .value {
   font-size: 0.875rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .empty {

--- a/src/components/value/ohri-value.scss
+++ b/src/components/value/ohri-value.scss
@@ -3,6 +3,7 @@
 .value {
   font-size: 0.875rem;
   font-weight: 500;
+  color: colors.$gray-60;
 }
 
 .empty {

--- a/src/components/value/view/ohri-field-value-view.component.tsx
+++ b/src/components/value/view/ohri-field-value-view.component.tsx
@@ -12,24 +12,12 @@ interface OHRIFieldValueViewProps {
   conceptName: string;
 }
 export const OHRIFieldValueView: React.FC<OHRIFieldValueViewProps> = ({ label, conceptName, value, isInline }) => (
-  <div className={styles.readonly}>
-    {isInline && (
-      <div className={styles.formField}>
-        <Row>
-          <Column lg={5} md={5}>
-            <OHRILabel value={label} tooltipText={conceptName} />
-          </Column>
-          <Column className={styles.value}>
-            {!isEmpty(value) ? <OHRIValueDisplay value={value} /> : <OHRIValueEmpty />}
-          </Column>
-        </Row>
-      </div>
-    )}
-    {!isInline && (
-      <div className={styles.formField}>
-        <OHRILabel value={label} tooltipText={conceptName} />
-        <div className={styles.value}>{value ? <OHRIValueDisplay value={value} /> : <OHRIValueEmpty />}</div>
-      </div>
-    )}
+  <div className={`${styles.flexrow}`}>
+    <div className={styles.flexColumn}>
+      <OHRILabel value={label} tooltipText={conceptName} />
+    </div>
+    <div className={`${styles.value} ${styles.flexColumn}`}>
+      {value ? <OHRIValueDisplay value={value} /> : <OHRIValueEmpty />}
+    </div>
   </div>
 );

--- a/src/components/value/view/ohri-field-value-view.component.tsx
+++ b/src/components/value/view/ohri-field-value-view.component.tsx
@@ -12,12 +12,35 @@ interface OHRIFieldValueViewProps {
   conceptName: string;
 }
 export const OHRIFieldValueView: React.FC<OHRIFieldValueViewProps> = ({ label, conceptName, value, isInline }) => (
-  <div className={`${styles.flexrow}`}>
-    <div className={styles.flexColumn}>
-      <OHRILabel value={label} tooltipText={conceptName} />
-    </div>
-    <div className={`${styles.value} ${styles.flexColumn}`}>
-      {value ? <OHRIValueDisplay value={value} /> : <OHRIValueEmpty />}
-    </div>
+  <div className={styles.readonly}>
+    {isInline && (
+      <div className={styles.formField}>
+        <Row>
+          <Column lg={5} md={5}>
+            <OHRILabel value={label} tooltipText={conceptName} />
+          </Column>
+          <Column className={styles.value}>
+            {!isEmpty(value) ? <OHRIValueDisplay value={value} /> : <OHRIValueEmpty />}
+          </Column>
+        </Row>
+      </div>
+    )}
+    {!isInline && (
+      <div className={styles.formField}>
+        <OHRILabel value={label} tooltipText={conceptName} />
+        <div className={styles.value}>{value ? <OHRIValueDisplay value={value} /> : <OHRIValueEmpty />}</div>
+      </div>
+    )}
   </div>
 );
+
+// isInline ? (
+//   <div className={styles.inlineFlexrow}>
+//     <div className={styles.inlineFlexColumn}>
+//       <OHRILabel value={label} tooltipText={conceptName} />
+//     </div>
+//     <div className={`${styles.inlineFlexColumn}`}>
+//       {value ? <OHRIValueDisplay value={value} /> : <OHRIValueEmpty />}
+//     </div>
+//   </div>
+// ) : null

--- a/src/components/value/view/ohri-field-value-view.component.tsx
+++ b/src/components/value/view/ohri-field-value-view.component.tsx
@@ -14,15 +14,13 @@ interface OHRIFieldValueViewProps {
 export const OHRIFieldValueView: React.FC<OHRIFieldValueViewProps> = ({ label, conceptName, value, isInline }) => (
   <div className={styles.readonly}>
     {isInline && (
-      <div className={styles.formField}>
-        <Row>
-          <Column lg={5} md={5}>
-            <OHRILabel value={label} tooltipText={conceptName} />
-          </Column>
-          <Column className={styles.value}>
-            {!isEmpty(value) ? <OHRIValueDisplay value={value} /> : <OHRIValueEmpty />}
-          </Column>
-        </Row>
+      <div className={styles.inlineFlexrow}>
+        <div className={styles.inlineFlexColumn}>
+          <OHRILabel value={label} tooltipText={conceptName} />
+        </div>
+        <div className={`${styles.inlineFlexColumn}`}>
+          {value ? <OHRIValueDisplay value={value} /> : <OHRIValueEmpty />}
+        </div>
       </div>
     )}
     {!isInline && (
@@ -33,14 +31,3 @@ export const OHRIFieldValueView: React.FC<OHRIFieldValueViewProps> = ({ label, c
     )}
   </div>
 );
-
-// isInline ? (
-//   <div className={styles.inlineFlexrow}>
-//     <div className={styles.inlineFlexColumn}>
-//       <OHRILabel value={label} tooltipText={conceptName} />
-//     </div>
-//     <div className={`${styles.inlineFlexColumn}`}>
-//       {value ? <OHRIValueDisplay value={value} /> : <OHRIValueEmpty />}
-//     </div>
-//   </div>
-// ) : null

--- a/src/components/value/view/ohri-field-value-view.component.tsx
+++ b/src/components/value/view/ohri-field-value-view.component.tsx
@@ -12,7 +12,7 @@ interface OHRIFieldValueViewProps {
   conceptName: string;
 }
 export const OHRIFieldValueView: React.FC<OHRIFieldValueViewProps> = ({ label, conceptName, value, isInline }) => (
-  <div className={styles.readonly}>
+  <>
     {isInline && (
       <div className={styles.inlineFlexrow}>
         <div className={styles.inlineFlexColumn}>
@@ -24,10 +24,12 @@ export const OHRIFieldValueView: React.FC<OHRIFieldValueViewProps> = ({ label, c
       </div>
     )}
     {!isInline && (
-      <div className={styles.formField}>
-        <OHRILabel value={label} tooltipText={conceptName} />
-        <div className={styles.value}>{value ? <OHRIValueDisplay value={value} /> : <OHRIValueEmpty />}</div>
+      <div className={styles.readonly}>
+        <div className={styles.formField}>
+          <OHRILabel value={label} tooltipText={conceptName} />
+          <div className={styles.value}>{value ? <OHRIValueDisplay value={value} /> : <OHRIValueEmpty />}</div>
+        </div>
       </div>
     )}
-  </div>
+  </>
 );

--- a/src/components/value/view/ohri-field-value-view.scss
+++ b/src/components/value/view/ohri-field-value-view.scss
@@ -1,22 +1,15 @@
-@use '@carbon/colors';
+// @use '@carbon/colors';
 
-.formField {
-  margin-top: 10px;
+.value{
+  // background-color: pink;
+}
+.flexrow{
+  display: flex;
+  flex-wrap: wrap;
+}
+.flexColumn{
+  width: 400px
 }
 
-.formField > div > div > label {
-  color: colors.$gray-70;
-}
 
-.readonly {
-  border-bottom: 0.5px colors.$gray-30;
-  border-style: solid;
-}
 
-.readonly > div {
-  padding-bottom: 7px !important;
-}
-
-.value {
-  color: colors.$gray-70;
-}

--- a/src/components/value/view/ohri-field-value-view.scss
+++ b/src/components/value/view/ohri-field-value-view.scss
@@ -1,6 +1,25 @@
-// @use '@carbon/colors';
+@use '@carbon/colors';
 
-.value{}
+.formField {
+  margin-top: 10px;
+}
+
+.formField > div > div > label {
+  color: colors.$gray-70;
+}
+
+.readonly {
+  border-bottom: 0.5px colors.$gray-30;
+  border-style: solid;
+}
+
+.readonly > div {
+  padding-bottom: 7px !important;
+}
+
+.value {
+  color: colors.$gray-70;
+}
 
 .inlineFlexrow{
   display: flex;
@@ -9,6 +28,3 @@
 .inlineFlexColumn{
   width: 300px
 }
-
-
-

--- a/src/components/value/view/ohri-field-value-view.scss
+++ b/src/components/value/view/ohri-field-value-view.scss
@@ -8,7 +8,7 @@
   flex-wrap: wrap;
 }
 .flexColumn{
-  width: 400px
+  width: 300px
 }
 
 

--- a/src/components/value/view/ohri-field-value-view.scss
+++ b/src/components/value/view/ohri-field-value-view.scss
@@ -1,7 +1,7 @@
 @use '@carbon/colors';
 
 .formField {
-  margin-top: 10px;
+  // margin-top: 10px;
 }
 
 .formField > div > div > label {
@@ -14,7 +14,7 @@
 }
 
 .readonly > div {
-  padding-bottom: 7px !important;
+  // padding-bottom: 7px !important;
 }
 
 .value {

--- a/src/components/value/view/ohri-field-value-view.scss
+++ b/src/components/value/view/ohri-field-value-view.scss
@@ -1,7 +1,7 @@
 @use '@carbon/colors';
 
 .formField {
-  // margin-top: 10px;
+  margin-top: 10px;
 }
 
 .formField > div > div > label {
@@ -14,7 +14,7 @@
 }
 
 .readonly > div {
-  // padding-bottom: 7px !important;
+  padding-bottom: 7px !important;
 }
 
 .value {

--- a/src/components/value/view/ohri-field-value-view.scss
+++ b/src/components/value/view/ohri-field-value-view.scss
@@ -1,13 +1,12 @@
 // @use '@carbon/colors';
 
-.value{
-  // background-color: pink;
-}
-.flexrow{
+.value{}
+
+.inlineFlexrow{
   display: flex;
   flex-wrap: wrap;
 }
-.flexColumn{
+.inlineFlexColumn{
   width: 300px
 }
 

--- a/src/ohri-form.component.scss
+++ b/src/ohri-form.component.scss
@@ -46,7 +46,7 @@
 }
 
 .minifiedFormContentBody {
-  margin-bottom: 3rem !important;
+  margin-bottom: 4rem !important;
 }
 
 .minifiedButtons {

--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -116,9 +116,18 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
   const postSubmissionHandlers = usePostSubmissionAction(refinedFormJson?.postSubmissionActions);
 
   const sessionMode = mode ? mode : encounterUUID || encounterUuid ? 'edit' : 'enter';
+
   const showSidebar = useMemo(() => {
     return workspaceLayout !== 'minimized' && scrollablePages.size > 0 && sessionMode !== 'embedded-view';
   }, [workspaceLayout, scrollablePages.size, sessionMode]);
+
+  const showPatientBanner = useMemo(() => {
+    return workspaceLayout != 'minimized' && patient?.id && sessionMode != 'embedded-view';
+  }, [patient?.id, sessionMode, workspaceLayout]);
+
+  const showButtonSet = useMemo(() => {
+    return workspaceLayout === 'minimized' && sessionMode != 'embedded-view';
+  }, [sessionMode, workspaceLayout]);
 
   useEffect(() => {
     const extDetails = {
@@ -287,7 +296,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                   </div>
                 )}
                 <div className={styles.ohriFormBody}>
-                  {showSidebar && sessionMode !== 'view' && (
+                  {showSidebar && (
                     <OHRIFormSidebar
                       isFormSubmitting={isSubmitting}
                       pagesWithErrors={pagesWithErrors}
@@ -303,9 +312,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                     />
                   )}
                   <div className={styles.formContent}>
-                    {workspaceLayout != 'minimized' && !patient?.id && sessionMode != 'embedded-view' && (
-                      <PatientBanner patient={patient} hideActionsOverflow={true} />
-                    )}
+                    {showPatientBanner && <PatientBanner patient={patient} hideActionsOverflow={true} />}
                     {refinedFormJson.markdown && (
                       <div className={styles.markdownContainer}>
                         <ReactMarkdown children={refinedFormJson.markdown.join('\n')} />
@@ -343,7 +350,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                         setIsSubmitting={setIsSubmitting}
                       />
                     </div>
-                    {sessionMode == 'view' && (
+                    {showButtonSet && (
                       <ButtonSet className={styles.minifiedButtons}>
                         <Button
                           kind="secondary"

--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -148,8 +148,10 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
       },
     };
 
-    registerExtension(extDetails);
-    attach(PatientChartWorkspaceHeaderSlot, extDetails.name);
+    if (sessionMode != 'embedded-view') {
+      registerExtension(extDetails);
+      attach(PatientChartWorkspaceHeaderSlot, extDetails.name);
+    }
 
     return () => {
       detach(PatientChartWorkspaceHeaderSlot, extDetails.name);

--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -287,7 +287,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                   </div>
                 )}
                 <div className={styles.ohriFormBody}>
-                  {showSidebar && (
+                  {showSidebar && sessionMode !== 'view' && (
                     <OHRIFormSidebar
                       isFormSubmitting={isSubmitting}
                       pagesWithErrors={pagesWithErrors}
@@ -339,30 +339,31 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                         setIsSubmitting={setIsSubmitting}
                       />
                     </div>
-                    {workspaceLayout === 'minimized' && (
-                      <ButtonSet className={styles.minifiedButtons}>
-                        <Button
-                          kind="secondary"
-                          onClick={() => {
-                            if (mode !== 'view' && isFormTouched) {
-                              setShowWarningModal(true);
-                              return;
-                            }
+                    {workspaceLayout === 'minimized' ||
+                      (sessionMode == 'view' && (
+                        <ButtonSet className={styles.minifiedButtons}>
+                          <Button
+                            kind="secondary"
+                            onClick={() => {
+                              if (mode !== 'view' && isFormTouched) {
+                                setShowWarningModal(true);
+                                return;
+                              }
 
-                            onCancel && onCancel();
-                            handleClose && handleClose();
-                          }}>
-                          {mode === 'view' ? 'Close' : 'Cancel'}
-                        </Button>
-                        <Button type="submit" disabled={mode === 'view' || isSubmitting}>
-                          {isSubmitting ? (
-                            <InlineLoading description={t('submitting', 'Submitting') + '...'} />
-                          ) : (
-                            <span>{t('save', 'Save')}</span>
-                          )}
-                        </Button>
-                      </ButtonSet>
-                    )}
+                              onCancel && onCancel();
+                              handleClose && handleClose();
+                            }}>
+                            {mode === 'view' ? 'Close' : 'Cancel'}
+                          </Button>
+                          <Button type="submit" disabled={mode === 'view' || isSubmitting}>
+                            {isSubmitting ? (
+                              <InlineLoading description={t('submitting', 'Submitting') + '...'} />
+                            ) : (
+                              <span>{t('save', 'Save')}</span>
+                            )}
+                          </Button>
+                        </ButtonSet>
+                      ))}
                   </div>
                 </div>
               </div>

--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -313,7 +313,11 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                     )}
                     <div
                       className={`${styles.formContentBody}
-                    ${workspaceLayout === 'minimized' ? `${styles.minifiedFormContentBody}` : ''}
+                    ${
+                      workspaceLayout === 'minimized' || sessionMode == 'view'
+                        ? `${styles.minifiedFormContentBody}`
+                        : ''
+                    }
                   `}>
                       <OHRIEncounterForm
                         formJson={refinedFormJson}

--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -339,31 +339,30 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                         setIsSubmitting={setIsSubmitting}
                       />
                     </div>
-                    {workspaceLayout === 'minimized' ||
-                      (sessionMode == 'view' && (
-                        <ButtonSet className={styles.minifiedButtons}>
-                          <Button
-                            kind="secondary"
-                            onClick={() => {
-                              if (mode !== 'view' && isFormTouched) {
-                                setShowWarningModal(true);
-                                return;
-                              }
+                    {sessionMode == 'view' && (
+                      <ButtonSet className={styles.minifiedButtons}>
+                        <Button
+                          kind="secondary"
+                          onClick={() => {
+                            if (mode !== 'view' && isFormTouched) {
+                              setShowWarningModal(true);
+                              return;
+                            }
 
-                              onCancel && onCancel();
-                              handleClose && handleClose();
-                            }}>
-                            {mode === 'view' ? 'Close' : 'Cancel'}
-                          </Button>
-                          <Button type="submit" disabled={mode === 'view' || isSubmitting}>
-                            {isSubmitting ? (
-                              <InlineLoading description={t('submitting', 'Submitting') + '...'} />
-                            ) : (
-                              <span>{t('save', 'Save')}</span>
-                            )}
-                          </Button>
-                        </ButtonSet>
-                      ))}
+                            onCancel && onCancel();
+                            handleClose && handleClose();
+                          }}>
+                          {mode === 'view' ? 'Close' : 'Cancel'}
+                        </Button>
+                        <Button type="submit" disabled={mode === 'view' || isSubmitting}>
+                          {isSubmitting ? (
+                            <InlineLoading description={t('submitting', 'Submitting') + '...'} />
+                          ) : (
+                            <span>{t('save', 'Save')}</span>
+                          )}
+                        </Button>
+                      </ButtonSet>
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -303,7 +303,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                     />
                   )}
                   <div className={styles.formContent}>
-                    {workspaceLayout != 'minimized' && patient?.id && (
+                    {workspaceLayout != 'minimized' && !patient?.id && (
                       <PatientBanner patient={patient} hideActionsOverflow={true} />
                     )}
                     {refinedFormJson.markdown && (

--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -117,8 +117,8 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
 
   const sessionMode = mode ? mode : encounterUUID || encounterUuid ? 'edit' : 'enter';
   const showSidebar = useMemo(() => {
-    return workspaceLayout !== 'minimized' && scrollablePages.size > 0;
-  }, [workspaceLayout, scrollablePages.size]);
+    return workspaceLayout !== 'minimized' && scrollablePages.size > 0 && sessionMode !== 'embedded-view';
+  }, [workspaceLayout, scrollablePages.size, sessionMode]);
 
   useEffect(() => {
     const extDetails = {
@@ -303,7 +303,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
                     />
                   )}
                   <div className={styles.formContent}>
-                    {workspaceLayout != 'minimized' && !patient?.id && (
+                    {workspaceLayout != 'minimized' && !patient?.id && sessionMode != 'embedded-view' && (
                       <PatientBanner patient={patient} hideActionsOverflow={true} />
                     )}
                     {refinedFormJson.markdown && (

--- a/src/utils/expression-runner.ts
+++ b/src/utils/expression-runner.ts
@@ -9,7 +9,7 @@ export interface FormNode {
 }
 
 export interface ExpressionContext {
-  mode: 'enter' | 'edit' | 'view';
+  mode: 'enter' | 'edit' | 'view' | 'embedded-view';
   myValue?: any;
   patient: any;
 }

--- a/src/utils/ohri-form-helper.ts
+++ b/src/utils/ohri-form-helper.ts
@@ -3,7 +3,7 @@ import { LayoutType } from '@openmrs/esm-framework';
 import { fetchConceptNameByUuid } from '../api/api';
 import { ConceptTrue } from '../constants';
 import { EncounterContext } from '../ohri-form-context';
-import { OHRIFormField, OHRIFormPage, OHRIFormSection, SubmissionHandler } from '../api/types';
+import { OHRIFormField, OHRIFormPage, OHRIFormSection, SessionMode, SubmissionHandler } from '../api/types';
 import { OHRIDefaultFieldValueValidator } from '../validators/default-value-validator';
 import { isEmpty } from '../validators/ohri-form-validator';
 import { isTrue } from './boolean-utils';
@@ -55,7 +55,11 @@ export function isInlineView(
   renderingType: 'single-line' | 'multiline' | 'automatic',
   layoutType: LayoutType,
   workspaceLayout: 'minimized' | 'maximized',
-) {
+  sessionMode: SessionMode,
+): boolean {
+  if (sessionMode == 'embedded-view') {
+    return sessionMode == 'embedded-view';
+  }
   if (renderingType == 'automatic') {
     return workspaceLayout == 'maximized' && layoutType.endsWith('desktop');
   }

--- a/src/utils/ohri-form-helper.ts
+++ b/src/utils/ohri-form-helper.ts
@@ -58,7 +58,7 @@ export function isInlineView(
   sessionMode: SessionMode,
 ): boolean {
   if (sessionMode == 'embedded-view') {
-    return sessionMode == 'embedded-view';
+    return true;
   }
   if (renderingType == 'automatic') {
     return workspaceLayout == 'maximized' && layoutType.endsWith('desktop');


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This pull request introduces a new mode in the form engine, referred to as "embedded-view." This mode is designed to present a version of the view mode in a consolidated format, where question and answer pairs are rendered inline within a single file. This format eliminates the typical accordion structure. 

The introduction of this mode addresses the specific requirement of embedding the form engine within a widget to showcase form details in a report-like format. To activate this mode, users can pass the prop `mode='embedded-view'` to the `<OHRIForm />` component. 

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1728" alt="Screenshot 2024-02-13 at 14 16 09" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/51090527/9cdb25e8-d1fe-4756-9240-9fc43b8b7a89">
<img width="1714" alt="Screenshot 2024-02-13 at 14 18 31" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/51090527/d4f821be-e9ae-4ff3-8292-49fec11dd9bf">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
