### PR TITLE
(feat) Remove millis prop from Toast component

### DIFF
--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -9,7 +9,6 @@ export function reportError(error: Error, t: TFunction): void {
       title: t('errorDescriptionTitle', 'Error'),
       kind: 'error',
       critical: true,
-      millis: 7000,
     });
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Following https://github.com/openmrs/openmrs-esm-core/pull/937, the Toast notification component no longer accepts a `millis` prop. This PR removes the prop from an invocation of `showToast` in the form engine.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
Per our [design guidelines](https://zeroheight.com/23a080e38/p/683580-notifications), error snackbars are probably a better fit for this use case in `error-utils.ts`. Toasts are meant to be used for system-generated notifications that are not a result of user action.