### PR TITLE
(feat) Extend encounter location to process AFE schema out of the box

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -65,6 +65,12 @@ export function getLocationsByTag(tag: string): Observable<{ uuid: string; displ
   );
 }
 
+export function getAllLocations(): Observable<{ uuid: string; display: string }[]> {
+  return openmrsObservableFetch(`/ws/rest/v1/location?v=custom:(uuid,display)`).pipe(
+    map(({ data }) => data['results']),
+  );
+}
+
 export async function getPreviousEncounter(patientUuid: string, encounterType: string) {
   const query = `patient=${patientUuid}&_sort=-_lastUpdated&_count=1&type=${encounterType}`;
   let response = await openmrsFetch(`/ws/fhir2/R4/Encounter?${query}`);

--- a/src/components/section/helpers.ts
+++ b/src/components/section/helpers.ts
@@ -17,6 +17,11 @@ export function getFieldControlWithFallback(question: OHRIFormField) {
     return getRegisteredControl('text');
   }
 
+  //Rendering overrides for existing AFE form schemas
+  if (question.type === 'encounterLocation') {
+    question.questionOptions.rendering = 'encounter-location';
+  }
+
   // Retrieve the registered control based on the specified rendering
   return getRegisteredControl(question.questionOptions.rendering);
 }

--- a/src/registry/inbuilt-components/control-templates.ts
+++ b/src/registry/inbuilt-components/control-templates.ts
@@ -15,12 +15,16 @@ export const controlTemplates: Array<ControlTemplate> = [
     datasource: {
       name: 'problem_datasource',
       config: {
-        class: ['8d4918b0-c2cc-11de-8d13-0010c6dffd0f', '8d492954-c2cc-11de-8d13-0010c6dffd0f','8d492b2a-c2cc-11de-8d13-0010c6dffd0f'],
+        class: [
+          '8d4918b0-c2cc-11de-8d13-0010c6dffd0f',
+          '8d492954-c2cc-11de-8d13-0010c6dffd0f',
+          '8d492b2a-c2cc-11de-8d13-0010c6dffd0f',
+        ],
       },
     },
   },
 ];
 
 export const getControlTemplate = (name: string) => {
-  return controlTemplates.find(template => template.name === name);
+  return controlTemplates.find((template) => template.name === name);
 };

--- a/src/registry/inbuilt-components/inbuiltControls.ts
+++ b/src/registry/inbuilt-components/inbuiltControls.ts
@@ -117,9 +117,9 @@ export const inbuiltControls: Array<RegistryItem<React.ComponentType<OHRIFormFie
     component: File,
     type: 'file',
   },
-  ...controlTemplates.map(template => ({
+  ...controlTemplates.map((template) => ({
     name: `${template.name}Control`,
-    component: templateToComponentMap.find(component => component.name === template.name).baseControlComponent,
+    component: templateToComponentMap.find((component) => component.name === template.name).baseControlComponent,
     type: template.name.toLowerCase(),
   })),
 ];


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The RFE was designed to pick encounter location based on the `rendering`. The AFE schemas however pick encounter location based on the `type`. This PR extends the component to understand both schemas.

## Screenshots

https://github.com/openmrs/openmrs-form-engine-lib/assets/12844964/4ff9904f-f2d2-4e2d-aa59-cfbccaf869a3



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
