### PR TITLE
(feat) Hide form side navigation for forms with only only page

### DIFF
--- a/src/ohri-form.component.tsx
+++ b/src/ohri-form.component.tsx
@@ -118,7 +118,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
   const sessionMode = mode ? mode : encounterUUID || encounterUuid ? 'edit' : 'enter';
 
   const showSidebar = useMemo(() => {
-    return workspaceLayout !== 'minimized' && scrollablePages.size > 0 && sessionMode !== 'embedded-view';
+    return workspaceLayout !== 'minimized' && scrollablePages.size > 1 && sessionMode !== 'embedded-view';
   }, [workspaceLayout, scrollablePages.size, sessionMode]);
 
   const showPatientBanner = useMemo(() => {
@@ -126,8 +126,8 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
   }, [patient?.id, sessionMode, workspaceLayout]);
 
   const showButtonSet = useMemo(() => {
-    return workspaceLayout === 'minimized' && sessionMode != 'embedded-view';
-  }, [sessionMode, workspaceLayout]);
+    return workspaceLayout === 'minimized' || 'maximized'  && sessionMode != 'embedded-view' && scrollablePages.size <= 1;
+  }, [sessionMode, workspaceLayout,scrollablePages]);
 
   useEffect(() => {
     const extDetails = {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Add ability to hide the form-engine navigation column if only one page exists as shown in the GIF below.

## Screenshots
https://www.loom.com/share/ca98349b95594e8993b71d97e4824ddf?sid=d7f48111-083f-4327-8d50-524dd4124d5e


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-2212

## Other
<!-- Anything not covered above -->
N/A