### PR TITLE
(fix) O3-1989: fix tooltip alignment for number input.

### DIFF
--- a/src/components/section/ohri-form-section.component.tsx
+++ b/src/components/section/ohri-form-section.component.tsx
@@ -75,7 +75,8 @@ const OHRIFormSection = ({ fields, onFieldChange }) => {
                       className={`${
                         fieldDescriptor.questionOptions.rendering == 'radio' ||
                         fieldDescriptor.questionOptions.rendering == 'date' ||
-                        fieldDescriptor.questionOptions.rendering == 'datetime'
+                        fieldDescriptor.questionOptions.rendering == 'datetime' ||
+                        fieldDescriptor.questionOptions.rendering == 'number'
                           ? ''
                           : styles.flexBasisOn
                       } ${fieldDescriptor.constrainMaxWidth && styles.controlWidthConstrained}`}>
@@ -83,8 +84,7 @@ const OHRIFormSection = ({ fields, onFieldChange }) => {
                     </div>
                     {fieldDescriptor.questionInfo && (
                       <div className={styles.questionInfoControl}>
-                        {' '}
-                        <OHRITooltip field={fieldDescriptor} />{' '}
+                        <OHRITooltip field={fieldDescriptor} />
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes the misplaced alignment of the info tooltip and the `number` input control. Basis formed from the discussions [here](https://arc.net/l/quote/gdijnbic).

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="739" alt="Screenshot 2024-04-14 at 11 35 36" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/51090527/1ebef42d-e76d-4dae-a026-bad2daa51e37">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
