### PR TITLE
(feat) 03 -2130: Add support of default answers for coded questions

### DIFF
--- a/src/components/encounter/ohri-encounter-form.component.tsx
+++ b/src/components/encounter/ohri-encounter-form.component.tsx
@@ -271,7 +271,6 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
           ) {
             const collection = matchingConcept.answers.map((answer) => {
               return {
-                ...answer,
                 concept: answer.concept,
                 label: answer.label,
               };

--- a/src/components/encounter/ohri-encounter-form.component.tsx
+++ b/src/components/encounter/ohri-encounter-form.component.tsx
@@ -266,6 +266,9 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
           field.meta = {
             concept: matchingConcept,
           };
+          if (!field.questionOptions.answers?.length && field.meta?.concept?.conceptClass?.display === 'Question' && field.meta?.concept?.answers?.length) {
+            field.questionOptions.answers = field.meta?.concept?.answers;  
+          }
           if (field.questionOptions.answers) {
             field.questionOptions.answers = field.questionOptions.answers.map((answer) => {
               const matchingAnswerConcept = findConceptByReference(answer.concept, concepts);

--- a/src/components/encounter/ohri-encounter-form.component.tsx
+++ b/src/components/encounter/ohri-encounter-form.component.tsx
@@ -263,32 +263,24 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
           const matchingConcept = findConceptByReference(field.questionOptions.concept, concepts);
           field.questionOptions.concept = matchingConcept ? matchingConcept.uuid : field.questionOptions.concept;
           field.label = field.label ? field.label : matchingConcept?.display;
-          // field.meta = {
-          //   concept: matchingConcept,
-          // };
           if (
             codedTypes.includes(field.questionOptions.rendering) &&
             !field.questionOptions.answers?.length &&
-            matchingConcept.conceptClass?.display === 'Question'
+            matchingConcept?.conceptClass?.display === 'Question' &&
+            matchingConcept?.answers?.length
           ) {
-            field.questionOptions.answers = matchingConcept?.answers.map((answer) => {
+            const collection = matchingConcept.answers.map((answer) => {
               return {
+                ...answer,
                 concept: answer.concept,
                 label: answer.label,
               };
             });
+            field.questionOptions.answers = collection;
           }
           field.meta = {
             concept: matchingConcept,
           };
-
-          if (
-            !field.questionOptions.answers?.length &&
-            field.meta?.concept?.conceptClass?.display === 'Question' &&
-            field.meta?.concept?.answers?.length
-          ) {
-            field.questionOptions.answers = field.meta?.concept?.answers;
-          }
           if (field.questionOptions.answers) {
             field.questionOptions.answers = field.questionOptions.answers.map((answer) => {
               const matchingAnswerConcept = findConceptByReference(answer.concept, concepts);

--- a/src/components/encounter/ohri-encounter-form.component.tsx
+++ b/src/components/encounter/ohri-encounter-form.component.tsx
@@ -271,8 +271,8 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
           ) {
             const collection = matchingConcept.answers.map((answer) => {
               return {
-                concept: answer.concept,
-                label: answer.label,
+                concept: answer.uuid,
+                label: answer.display,
               };
             });
             field.questionOptions.answers = collection;

--- a/src/components/encounter/ohri-encounter-form.component.tsx
+++ b/src/components/encounter/ohri-encounter-form.component.tsx
@@ -269,13 +269,12 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
             matchingConcept?.conceptClass?.display === 'Question' &&
             matchingConcept?.answers?.length
           ) {
-            const collection = matchingConcept.answers.map((answer) => {
+            field.questionOptions.answers = matchingConcept.answers.map((answer) => {
               return {
-                concept: answer.uuid,
-                label: answer.display,
+                concept: answer?.uuid,
+                label: answer?.display,
               };
             });
-            field.questionOptions.answers = collection;
           }
           field.meta = {
             concept: matchingConcept,

--- a/src/components/encounter/ohri-encounter-form.component.tsx
+++ b/src/components/encounter/ohri-encounter-form.component.tsx
@@ -1,6 +1,6 @@
 import React, { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
 import { SessionLocation, showToast, useLayoutType, Visit } from '@openmrs/esm-framework';
-import { ConceptFalse, ConceptTrue } from '../../constants';
+import { ConceptFalse, ConceptTrue, codedTypes } from '../../constants';
 import {
   OHRIFormField,
   OHRIFormPage as OHRIFormPageProps,
@@ -263,11 +263,31 @@ export const OHRIEncounterForm: React.FC<OHRIEncounterFormProps> = ({
           const matchingConcept = findConceptByReference(field.questionOptions.concept, concepts);
           field.questionOptions.concept = matchingConcept ? matchingConcept.uuid : field.questionOptions.concept;
           field.label = field.label ? field.label : matchingConcept?.display;
+          // field.meta = {
+          //   concept: matchingConcept,
+          // };
+          if (
+            codedTypes.includes(field.questionOptions.rendering) &&
+            !field.questionOptions.answers?.length &&
+            matchingConcept.conceptClass?.display === 'Question'
+          ) {
+            field.questionOptions.answers = matchingConcept?.answers.map((answer) => {
+              return {
+                concept: answer.concept,
+                label: answer.label,
+              };
+            });
+          }
           field.meta = {
             concept: matchingConcept,
           };
-          if (!field.questionOptions.answers?.length && field.meta?.concept?.conceptClass?.display === 'Question' && field.meta?.concept?.answers?.length) {
-            field.questionOptions.answers = field.meta?.concept?.answers;  
+
+          if (
+            !field.questionOptions.answers?.length &&
+            field.meta?.concept?.conceptClass?.display === 'Question' &&
+            field.meta?.concept?.answers?.length
+          ) {
+            field.questionOptions.answers = field.meta?.concept?.answers;
           }
           if (field.questionOptions.answers) {
             field.questionOptions.answers = field.questionOptions.answers.map((answer) => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,3 +9,4 @@ export const encounterRepresentation =
   'names:(uuid,conceptNameType,name))))';
 export const OHRIFormsStore = 'ohri-forms-engine-store';
 export const PatientChartWorkspaceHeaderSlot = 'patient-chart-workspace-header-slot';
+export const codedTypes = ['radio', 'checkbox', 'select', 'content-switcher'];

--- a/src/hooks/useConcepts.tsx
+++ b/src/hooks/useConcepts.tsx
@@ -2,7 +2,7 @@ import useSWRImmutable from 'swr/immutable';
 import { openmrsFetch, OpenmrsResource } from '@openmrs/esm-framework';
 
 const conceptRepresentation =
-  'custom:(uuid,display,conceptMappings:(conceptReferenceTerm:(conceptSource:(name),code)))';
+  'custom:(uuid,display,conceptClass:(uuid,display),answers:(uuid,display),conceptMappings:(conceptReferenceTerm:(conceptSource:(name),code)))';
 
 export function useConcepts(references: Set<string>) {
   // TODO: handle paging (ie when number of concepts greater than default limit per page)

--- a/src/validators/default-value-validator.ts
+++ b/src/validators/default-value-validator.ts
@@ -1,9 +1,9 @@
 import dayjs from 'dayjs';
 import { FieldValidator, OHRIFormField } from '../api/types';
+import { codedTypes } from '../constants';
 
 export const OHRIDefaultFieldValueValidator: FieldValidator = {
   validate: (field: OHRIFormField, value: any) => {
-    const codedTypes = ['radio', 'checkbox', 'select', 'content-switcher'];
     if (codedTypes.includes(field.questionOptions.rendering)) {
       // check whether value exists in answers
       if (!field.questionOptions.answers?.find((answer) => answer.concept == value)) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR is dependent on https://github.com/openmrs/openmrs-form-engine-lib/pull/189 . It implements the aspect of supporting default answers for questions of concept Question incase answers for a question are not provided.
We consider supporting should render all the answer concepts associated with that concept in the concept dictionary as answer set 
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
