### PR TITLE
(feat) O3-3052 Support date-options within date input component

### DIFF
--- a/src/components/inputs/content-switcher/content-switcher.component.tsx
+++ b/src/components/inputs/content-switcher/content-switcher.component.tsx
@@ -10,9 +10,10 @@ import { FormContext } from '../../../form-context';
 import { type FormFieldProps } from '../../../types';
 import FieldValueView from '../../value/view/field-value-view.component';
 import InlineDate from '../inline-date/inline-date.component';
+import { getQuestionValue } from '../../../utils/common-utils';
+import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 import styles from './content-switcher.scss';
-import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
   const { t } = useTranslation();
@@ -27,26 +28,14 @@ const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, handler
       const { value } = previousValue;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, null);
-      question.value =
-        obsDate === undefined
-          ? handler?.handleFieldSubmission(question, value, encounterContext)
-          : handler?.handleFieldSubmission(question, value, {
-              ...encounterContext,
-              encounterDate: obsDate !== undefined ? obsDate : undefined,
-            });
+      question.value = getQuestionValue({ obsDate, question, value, handler, encounterContext });
     }
   }, [previousValue]);
 
   const handleChange = (value) => {
     setFieldValue(question.id, value?.name);
     onChange(question.id, value?.name, setErrors, null);
-    question.value =
-      obsDate === undefined
-        ? handler?.handleFieldSubmission(question, value, encounterContext)
-        : handler?.handleFieldSubmission(question, value, {
-            ...encounterContext,
-            encounterDate: obsDate !== undefined ? obsDate : undefined,
-          });
+    question.value = getQuestionValue({ obsDate, question, value, handler, encounterContext });
   };
 
   const selectedIndex = useMemo(
@@ -100,7 +89,6 @@ const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, handler
             <InlineDate
               question={question}
               setObsDateTime={(value) => setObsDate(value)}
-              onChange={() => {}}
             />
           </div>
         ) : (

--- a/src/components/inputs/content-switcher/content-switcher.component.tsx
+++ b/src/components/inputs/content-switcher/content-switcher.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import { FormGroup, ContentSwitcher as CdsContentSwitcher, Switch } from '@carbon/react';
@@ -19,20 +19,34 @@ const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, handler
   const [field] = useField(question.id);
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
   const { errors, setErrors } = useFieldValidationResults(question);
+  const [obsDate, setObsDate] = useState<Date>();
+
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
       const { value } = previousValue;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, null);
-      handler?.handleFieldSubmission(question, value, encounterContext);
+      question.value =
+        obsDate === undefined
+          ? handler?.handleFieldSubmission(question, value, encounterContext)
+          : handler?.handleFieldSubmission(question, value, {
+              ...encounterContext,
+              encounterDate: obsDate !== undefined ? obsDate : undefined,
+            });
     }
   }, [previousValue]);
 
   const handleChange = (value) => {
     setFieldValue(question.id, value?.name);
     onChange(question.id, value?.name, setErrors, null);
-    handler?.handleFieldSubmission(question, value?.name, encounterContext);
+    question.value =
+      obsDate === undefined
+        ? handler?.handleFieldSubmission(question, value, encounterContext)
+        : handler?.handleFieldSubmission(question, value, {
+            ...encounterContext,
+            encounterDate: obsDate !== undefined ? obsDate : undefined,
+          });
   };
 
   const selectedIndex = useMemo(
@@ -80,10 +94,17 @@ const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, handler
             />
           ))}
         </CdsContentSwitcher>
-        {question.questionOptions.showDate && (
+
+        {question.questionOptions.showDate === 'true' ? (
           <div style={{ marginTop: '5px' }}>
-            <InlineDate question={question} onChange={() => {}} handler={undefined} />
+            <InlineDate
+              question={question}
+              setObsDateTime={(value) => setObsDate(value)}
+              onChange={() => {}}
+            />
           </div>
+        ) : (
+          ''
         )}
       </FormGroup>
     )

--- a/src/components/inputs/content-switcher/content-switcher.component.tsx
+++ b/src/components/inputs/content-switcher/content-switcher.component.tsx
@@ -35,7 +35,7 @@ const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, handler
   const handleChange = (value) => {
     setFieldValue(question.id, value?.name);
     onChange(question.id, value?.name, setErrors, null);
-    question.value = getQuestionValue({ obsDate, question, value, handler, encounterContext });
+    question.value = getQuestionValue({ obsDate, question, value: value?.name, handler, encounterContext });
   };
 
   const selectedIndex = useMemo(

--- a/src/components/inputs/content-switcher/content-switcher.component.tsx
+++ b/src/components/inputs/content-switcher/content-switcher.component.tsx
@@ -9,6 +9,8 @@ import { isTrue } from '../../../utils/boolean-utils';
 import { FormContext } from '../../../form-context';
 import { type FormFieldProps } from '../../../types';
 import FieldValueView from '../../value/view/field-value-view.component';
+import InlineDate from '../inline-date/inline-date.component';
+
 import styles from './content-switcher.scss';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
@@ -78,6 +80,11 @@ const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, handler
             />
           ))}
         </CdsContentSwitcher>
+        {question.questionOptions.showDate && (
+          <div style={{ marginTop: '5px' }}>
+            <InlineDate question={question} onChange={() => {}} handler={undefined} />
+          </div>
+        )}
       </FormGroup>
     )
   );

--- a/src/components/inputs/content-switcher/content-switcher.component.tsx
+++ b/src/components/inputs/content-switcher/content-switcher.component.tsx
@@ -91,9 +91,7 @@ const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, handler
               setObsDateTime={(value) => setObsDate(value)}
             />
           </div>
-        ) : (
-          ''
-        )}
+        ) : null}
       </FormGroup>
     )
   );

--- a/src/components/inputs/content-switcher/content-switcher.component.tsx
+++ b/src/components/inputs/content-switcher/content-switcher.component.tsx
@@ -28,14 +28,14 @@ const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, handler
       const { value } = previousValue;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, null);
-      question.value = getQuestionValue({ obsDate, question, value, handler, encounterContext });
+      getQuestionValue({ obsDate, question, value, handler, encounterContext });
     }
   }, [previousValue]);
 
   const handleChange = (value) => {
     setFieldValue(question.id, value?.name);
     onChange(question.id, value?.name, setErrors, null);
-    question.value = getQuestionValue({ obsDate, question, value: value?.name, handler, encounterContext });
+    getQuestionValue({ obsDate, question, value: value?.name, handler, encounterContext });
   };
 
   const selectedIndex = useMemo(

--- a/src/components/inputs/content-switcher/content-switcher.test.tsx
+++ b/src/components/inputs/content-switcher/content-switcher.test.tsx
@@ -73,6 +73,16 @@ const renderForm = (initialValues) => {
   );
 };
 
+const mockI18next = {
+  language: 'en',
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'i18next', {
+    value: mockI18next,
+  });
+});
+
 describe('content-switcher input field', () => {
   afterEach(() => {
     // teardown

--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -11,7 +11,7 @@ import { isEmpty } from '../../../validators/form-validator';
 import { FormContext } from '../../../form-context';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
-import { useFieldValidationResults } from 'src/hooks/useFieldValidationResults';
+import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 import styles from './date.scss';
 

--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -11,6 +11,8 @@ import { isEmpty } from '../../../validators/form-validator';
 import { FormContext } from '../../../form-context';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
+import InlineDate from '../inline-date/inline-date.component';
+
 import styles from './date.scss';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
@@ -181,6 +183,11 @@ const DateField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
             ''
           )}
         </div>
+        {question.questionOptions.showDate && (
+          <div style={{ marginTop: '5px' }}>
+            <InlineDate question={question} onChange={() => {}} handler={undefined} />
+          </div>
+        )}
       </>
     )
   );

--- a/src/components/inputs/file/file.component.tsx
+++ b/src/components/inputs/file/file.component.tsx
@@ -4,11 +4,13 @@ import { useTranslation } from 'react-i18next';
 import { isTrue } from '../../../utils/boolean-utils';
 import Camera from '../camera/camera.component';
 import { Close, DocumentPdf } from '@carbon/react/icons';
-import styles from './file.scss';
-import { createAttachment } from '../../../utils/common-utils';
+import { createAttachment, getQuestionValue } from '../../../utils/common-utils';
 import { type FormFieldProps } from '../../../types';
 import { FormContext } from '../../../form-context';
 import { isInlineView } from '../../../utils/form-helper';
+import InlineDate from '../inline-date/inline-date.component';
+
+import styles from './file.scss';
 
 interface FileProps extends FormFieldProps {}
 type AllowedModes = 'uploader' | 'camera' | 'edit' | '';
@@ -20,6 +22,7 @@ const File: React.FC<FileProps> = ({ question, handler }) => {
   const [selectedFiles, setSelectedFiles] = useState(null); // Add state for selected files
   const [imagePreview, setImagePreview] = useState(null);
   const [uploadMode, setUploadMode] = useState<AllowedModes>('');
+  const [obsDate, setObsDate] = useState<Date>();
 
   useEffect(() => {
     if (encounterContext.sessionMode === 'edit') {
@@ -66,7 +69,7 @@ const File: React.FC<FileProps> = ({ question, handler }) => {
     setSelectedFiles(newSelectedFiles);
     setImagePreview(null);
     setFieldValue(question.id, newSelectedFiles);
-    handler?.handleFieldSubmission(question, newSelectedFiles, encounterContext);
+    question.value = getQuestionValue({ obsDate, question, value: newSelectedFiles, handler, encounterContext });
   };
 
   const setImages = (newImage) => {
@@ -74,7 +77,7 @@ const File: React.FC<FileProps> = ({ question, handler }) => {
     setImagePreview(newImage);
     setCameraWidgetVisible(false);
     setFieldValue(question.id, newImage);
-    handler?.handleFieldSubmission(question, newImage, encounterContext);
+    question.value = getQuestionValue({ obsDate, question, value: newImage, handler, encounterContext });
   };
 
   return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (
@@ -178,6 +181,16 @@ const File: React.FC<FileProps> = ({ question, handler }) => {
           )}
         </div>
       )}
+      {question.questionOptions.showDate === 'true' ? (
+          <div style={{ marginTop: '5px' }}>
+            <InlineDate
+              question={question}
+              setObsDateTime={(value) => setObsDate(value)}
+            />
+          </div>
+        ) : (
+          ''
+        )}
     </div>
   );
 };

--- a/src/components/inputs/file/file.component.tsx
+++ b/src/components/inputs/file/file.component.tsx
@@ -69,7 +69,7 @@ const File: React.FC<FileProps> = ({ question, handler }) => {
     setSelectedFiles(newSelectedFiles);
     setImagePreview(null);
     setFieldValue(question.id, newSelectedFiles);
-    question.value = getQuestionValue({ obsDate, question, value: newSelectedFiles, handler, encounterContext });
+    getQuestionValue({ obsDate, question, value: newSelectedFiles, handler, encounterContext });
   };
 
   const setImages = (newImage) => {
@@ -77,7 +77,7 @@ const File: React.FC<FileProps> = ({ question, handler }) => {
     setImagePreview(newImage);
     setCameraWidgetVisible(false);
     setFieldValue(question.id, newImage);
-    question.value = getQuestionValue({ obsDate, question, value: newImage, handler, encounterContext });
+    getQuestionValue({ obsDate, question, value: newImage, handler, encounterContext });
   };
 
   return encounterContext.sessionMode == 'view' || isTrue(question.readonly) ? (

--- a/src/components/inputs/file/file.component.tsx
+++ b/src/components/inputs/file/file.component.tsx
@@ -188,9 +188,7 @@ const File: React.FC<FileProps> = ({ question, handler }) => {
               setObsDateTime={(value) => setObsDate(value)}
             />
           </div>
-        ) : (
-          ''
-        )}
+        ) : null}
     </div>
   );
 };

--- a/src/components/inputs/inline-date/inline-date.component.tsx
+++ b/src/components/inputs/inline-date/inline-date.component.tsx
@@ -12,7 +12,6 @@ import styles from './inline-date.scss';
 const locale = window.i18next.language == 'en' ? 'en-GB' : window.i18next.language;
 const dateFormatter = new Intl.DateTimeFormat(locale);
 
-
 const InlineDate: React.FC<InlineDateProps> = ({ question, setObsDateTime }) => {
   const [field, meta] = useField(question.id);
   const { setFieldValue } = React.useContext(FormContext);
@@ -29,6 +28,7 @@ const InlineDate: React.FC<InlineDateProps> = ({ question, setObsDateTime }) => 
 
   const onDateChange = ([date]) => {
     const refinedDate = date instanceof Date ? new Date(date.getTime() - date.getTimezoneOffset() * 60000) : date;
+    setFieldValue(`inline-${question.id}`, refinedDate);
     setObsDateTime(refinedDate);
   };
 
@@ -74,7 +74,7 @@ const InlineDate: React.FC<InlineDateProps> = ({ question, setObsDateTime }) => 
           className={`${styles.boldedLabel} ${isFieldRequiredError ? styles.errorLabel : ''}`}
           dateFormat={carbonDateformat}>
           <DatePickerInput
-            id={question.id}
+            id={`inline-${question.id}`}
             placeholder={placeholder}
             labelText={` Date of ${question.label}`}
             value={field.value instanceof Date ? field.value.toLocaleDateString(locale) : field.value}

--- a/src/components/inputs/inline-date/inline-date.component.tsx
+++ b/src/components/inputs/inline-date/inline-date.component.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import dayjs from 'dayjs';
-import { type FormFieldProps } from '../../../types';
+import { type InlineDateProps } from '../../../types';
 import { FormContext } from '../../../form-context';
 import { fieldRequiredErrCode } from '../../../validators/form-validator';
 import { DatePicker } from '@carbon/react';
@@ -12,7 +12,8 @@ import styles from './inline-date.scss';
 const locale = window.i18next.language == 'en' ? 'en-GB' : window.i18next.language;
 const dateFormatter = new Intl.DateTimeFormat(locale);
 
-const InlineDate: React.FC<FormFieldProps> = ({ question, handler, previousValue }) => {
+
+const InlineDate: React.FC<InlineDateProps> = ({ question, setObsDateTime }) => {
   const [field, meta] = useField(question.id);
   const { setFieldValue } = React.useContext(FormContext);
   const [errors, setErrors] = useState([]);
@@ -28,8 +29,7 @@ const InlineDate: React.FC<FormFieldProps> = ({ question, handler, previousValue
 
   const onDateChange = ([date]) => {
     const refinedDate = date instanceof Date ? new Date(date.getTime() - date.getTimezoneOffset() * 60000) : date;
-    setFieldValue(question.id, refinedDate);
-    question.value = '';
+    setObsDateTime(refinedDate);
   };
 
   const { placeholder, carbonDateformat } = useMemo(() => {

--- a/src/components/inputs/inline-date/inline-date.component.tsx
+++ b/src/components/inputs/inline-date/inline-date.component.tsx
@@ -13,7 +13,7 @@ const locale = window.i18next.language == 'en' ? 'en-GB' : window.i18next.langua
 const dateFormatter = new Intl.DateTimeFormat(locale);
 
 const InlineDate: React.FC<InlineDateProps> = ({ question, setObsDateTime }) => {
-  const [field, meta] = useField(question.id);
+  const [field, meta] = useField(`inline-${question.id}`);
   const { setFieldValue } = React.useContext(FormContext);
   const [errors, setErrors] = useState([]);
   const [warnings, setWarnings] = useState([]);

--- a/src/components/inputs/inline-date/inline-date.component.tsx
+++ b/src/components/inputs/inline-date/inline-date.component.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import dayjs from 'dayjs';
+import { OHRIFormFieldProps } from '../../../api/types';
+import { OHRIFormContext } from '../../../ohri-form-context';
+import { fieldRequiredErrCode } from '../../../validators/ohri-form-validator';
+import { DatePicker } from '@carbon/react';
+import { DatePickerInput } from '@carbon/react';
+import styles from './inline-date.scss';
+import { useField } from 'formik';
+
+const locale = window.i18next.language == 'en' ? 'en-GB' : window.i18next.language;
+const dateFormatter = new Intl.DateTimeFormat(locale);
+
+const InlineDate: React.FC<OHRIFormFieldProps> = ({ question, handler, previousValue }) => {
+  const [field, meta] = useField(question.id);
+  const { setFieldValue, encounterContext, layoutType, workspaceLayout, fields } = React.useContext(OHRIFormContext);
+  const [errors, setErrors] = useState([]);
+  const [warnings, setWarnings] = useState([]);
+  const isFieldRequiredError = useMemo(() => errors[0]?.errCode == fieldRequiredErrCode, [errors]);
+
+  useEffect(() => {
+    if (question['submission']) {
+      question['submission'].errors && setErrors(question['submission'].errors);
+      question['submission'].warnings && setWarnings(question['submission'].warnings);
+    }
+  }, [question['submission']]);
+
+  const onDateChange = ([date]) => {
+    const refinedDate = date instanceof Date ? new Date(date.getTime() - date.getTimezoneOffset() * 60000) : date;
+    setFieldValue(question.id, refinedDate);
+  };
+
+  const { placeholder, carbonDateformat } = useMemo(() => {
+    const formatObj = dateFormatter.formatToParts(new Date());
+    const placeholder = formatObj
+      .map((obj) => {
+        switch (obj.type) {
+          case 'day':
+            return 'dd';
+          case 'month':
+            return 'mm';
+          case 'year':
+            return 'yyyy';
+          default:
+            return obj.value;
+        }
+      })
+      .join('');
+    const carbonDateformat = formatObj
+      .map((obj) => {
+        switch (obj.type) {
+          case 'day':
+            return 'd';
+          case 'month':
+            return 'm';
+          case 'year':
+            return 'Y';
+          default:
+            return obj.value;
+        }
+      })
+      .join('');
+    return { placeholder: placeholder, carbonDateformat: carbonDateformat };
+  }, []);
+
+  return (
+    <div className={styles.datetime}>
+      <div>
+        <DatePicker
+          datePickerType="single"
+          onChange={onDateChange}
+          className={`${styles.boldedLabel} ${isFieldRequiredError ? styles.errorLabel : ''}`}
+          dateFormat={carbonDateformat}>
+          <DatePickerInput
+            id={question.id}
+            placeholder={placeholder}
+            labelText={question.label}
+            value={field.value instanceof Date ? field.value.toLocaleDateString(locale) : field.value}
+            onChange={(e) => onDateChange([dayjs(e.target.value, placeholder.toUpperCase()).toDate()])}
+            disabled={question.disabled}
+            invalid={!isFieldRequiredError && errors.length > 0}
+            invalidText={errors[0]?.message}
+            warn={warnings.length > 0}
+            warnText={warnings[0]?.message}
+            readOnly={question.readonly}
+          />
+        </DatePicker>
+      </div>
+    </div>
+  );
+};
+
+export default InlineDate;

--- a/src/components/inputs/inline-date/inline-date.component.tsx
+++ b/src/components/inputs/inline-date/inline-date.component.tsx
@@ -1,19 +1,20 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import dayjs from 'dayjs';
-import { OHRIFormFieldProps } from '../../../api/types';
-import { OHRIFormContext } from '../../../ohri-form-context';
-import { fieldRequiredErrCode } from '../../../validators/ohri-form-validator';
+import { type FormFieldProps } from '../../../types';
+import { FormContext } from '../../../form-context';
+import { fieldRequiredErrCode } from '../../../validators/form-validator';
 import { DatePicker } from '@carbon/react';
 import { DatePickerInput } from '@carbon/react';
-import styles from './inline-date.scss';
 import { useField } from 'formik';
+
+import styles from './inline-date.scss';
 
 const locale = window.i18next.language == 'en' ? 'en-GB' : window.i18next.language;
 const dateFormatter = new Intl.DateTimeFormat(locale);
 
-const InlineDate: React.FC<OHRIFormFieldProps> = ({ question, handler, previousValue }) => {
+const InlineDate: React.FC<FormFieldProps> = ({ question, handler, previousValue }) => {
   const [field, meta] = useField(question.id);
-  const { setFieldValue, encounterContext, layoutType, workspaceLayout, fields } = React.useContext(OHRIFormContext);
+  const { setFieldValue } = React.useContext(FormContext);
   const [errors, setErrors] = useState([]);
   const [warnings, setWarnings] = useState([]);
   const isFieldRequiredError = useMemo(() => errors[0]?.errCode == fieldRequiredErrCode, [errors]);
@@ -28,6 +29,7 @@ const InlineDate: React.FC<OHRIFormFieldProps> = ({ question, handler, previousV
   const onDateChange = ([date]) => {
     const refinedDate = date instanceof Date ? new Date(date.getTime() - date.getTimezoneOffset() * 60000) : date;
     setFieldValue(question.id, refinedDate);
+    question.value = '';
   };
 
   const { placeholder, carbonDateformat } = useMemo(() => {
@@ -74,7 +76,7 @@ const InlineDate: React.FC<OHRIFormFieldProps> = ({ question, handler, previousV
           <DatePickerInput
             id={question.id}
             placeholder={placeholder}
-            labelText={question.label}
+            labelText={` Date of ${question.label}`}
             value={field.value instanceof Date ? field.value.toLocaleDateString(locale) : field.value}
             onChange={(e) => onDateChange([dayjs(e.target.value, placeholder.toUpperCase()).toDate()])}
             disabled={question.disabled}

--- a/src/components/inputs/inline-date/inline-date.component.tsx
+++ b/src/components/inputs/inline-date/inline-date.component.tsx
@@ -13,16 +13,16 @@ const locale = window.i18next?.language == 'en' ? 'en-GB' : window.i18next?.lang
 const dateFormatter = new Intl.DateTimeFormat(locale);
 
 const InlineDate: React.FC<InlineDateProps> = ({ question, setObsDateTime }) => {
-  const [field, meta] = useField(`inline-${question.id}`);
+  const [field] = useField(`inline-${question.id}`);
   const { setFieldValue } = React.useContext(FormContext);
   const [errors, setErrors] = useState([]);
   const [warnings, setWarnings] = useState([]);
   const isFieldRequiredError = useMemo(() => errors[0]?.errCode == fieldRequiredErrCode, [errors]);
 
   useEffect(() => {
-    if (question['submission']) {
-      question['submission'].errors && setErrors(question['submission'].errors);
-      question['submission'].warnings && setWarnings(question['submission'].warnings);
+    if (question?.meta?.submission) {
+      question?.meta?.submission?.errors && setErrors(question?.meta?.submission?.errors);
+      question?.meta?.submission?.warnings && setWarnings(question?.meta?.submission?.warnings);
     }
   }, [question['submission']]);
 
@@ -30,7 +30,7 @@ const InlineDate: React.FC<InlineDateProps> = ({ question, setObsDateTime }) => 
     const refinedDate = date instanceof Date ? new Date(date.getTime() - date.getTimezoneOffset() * 60000) : date;
     setFieldValue(`inline-${question.id}`, refinedDate);
     setObsDateTime(refinedDate);
-    question.value = Array.isArray(question?.value) ? question.value.map(value => ({...value, obsDatetime: refinedDate })) : {...question?.value, obsDatetime: refinedDate };
+    Array.isArray(question?.meta?.submission.newValue) ? question?.meta?.submission?.newValue.map(value => ({...value, obsDatetime: refinedDate })) : {...question?.value, obsDatetime: refinedDate };
   };
 
   const { placeholder, carbonDateformat } = useMemo(() => {
@@ -80,7 +80,7 @@ const InlineDate: React.FC<InlineDateProps> = ({ question, setObsDateTime }) => 
             labelText={` Date of ${question.label}`} // needs translation
             value={field.value instanceof Date ? field.value.toLocaleDateString(locale) : field.value}
             onChange={(e) => onDateChange([dayjs(e.target.value, placeholder.toUpperCase()).toDate()])}
-            disabled={question.disabled || !question?.value}
+            disabled={question.disabled || !question?.meta?.submission?.newValue}
             invalid={!isFieldRequiredError && errors.length > 0}
             invalidText={errors[0]?.message}
             warn={warnings.length > 0}

--- a/src/components/inputs/inline-date/inline-date.component.tsx
+++ b/src/components/inputs/inline-date/inline-date.component.tsx
@@ -9,7 +9,7 @@ import { useField } from 'formik';
 
 import styles from './inline-date.scss';
 
-const locale = window.i18next.language == 'en' ? 'en-GB' : window.i18next.language;
+const locale = window.i18next?.language == 'en' ? 'en-GB' : window.i18next?.language;
 const dateFormatter = new Intl.DateTimeFormat(locale);
 
 const InlineDate: React.FC<InlineDateProps> = ({ question, setObsDateTime }) => {

--- a/src/components/inputs/inline-date/inline-date.component.tsx
+++ b/src/components/inputs/inline-date/inline-date.component.tsx
@@ -30,6 +30,7 @@ const InlineDate: React.FC<InlineDateProps> = ({ question, setObsDateTime }) => 
     const refinedDate = date instanceof Date ? new Date(date.getTime() - date.getTimezoneOffset() * 60000) : date;
     setFieldValue(`inline-${question.id}`, refinedDate);
     setObsDateTime(refinedDate);
+    question.value = Array.isArray(question?.value) ? question.value.map(value => ({...value, obsDatetime: refinedDate })) : {...question?.value, obsDatetime: refinedDate };
   };
 
   const { placeholder, carbonDateformat } = useMemo(() => {
@@ -76,10 +77,10 @@ const InlineDate: React.FC<InlineDateProps> = ({ question, setObsDateTime }) => 
           <DatePickerInput
             id={`inline-${question.id}`}
             placeholder={placeholder}
-            labelText={` Date of ${question.label}`}
+            labelText={` Date of ${question.label}`} // needs translation
             value={field.value instanceof Date ? field.value.toLocaleDateString(locale) : field.value}
             onChange={(e) => onDateChange([dayjs(e.target.value, placeholder.toUpperCase()).toDate()])}
-            disabled={question.disabled}
+            disabled={question.disabled || !question?.value}
             invalid={!isFieldRequiredError && errors.length > 0}
             invalidText={errors[0]?.message}
             warn={warnings.length > 0}

--- a/src/components/inputs/inline-date/inline-date.component.tsx
+++ b/src/components/inputs/inline-date/inline-date.component.tsx
@@ -24,13 +24,13 @@ const InlineDate: React.FC<InlineDateProps> = ({ question, setObsDateTime }) => 
       question?.meta?.submission?.errors && setErrors(question?.meta?.submission?.errors);
       question?.meta?.submission?.warnings && setWarnings(question?.meta?.submission?.warnings);
     }
-  }, [question['submission']]);
+  }, [question.meta?.submission]);
 
   const onDateChange = ([date]) => {
     const refinedDate = date instanceof Date ? new Date(date.getTime() - date.getTimezoneOffset() * 60000) : date;
     setFieldValue(`inline-${question.id}`, refinedDate);
     setObsDateTime(refinedDate);
-    Array.isArray(question?.meta?.submission.newValue) ? question?.meta?.submission?.newValue.map(value => ({...value, obsDatetime: refinedDate })) : {...question?.value, obsDatetime: refinedDate };
+    question.meta.submission.newValue = Array.isArray(question?.meta?.submission.newValue) ? question?.meta?.submission?.newValue.map(value => ({...value, obsDatetime: refinedDate })) : {...question?.meta?.submission?.newValue, obsDatetime: refinedDate };
   };
 
   const { placeholder, carbonDateformat } = useMemo(() => {

--- a/src/components/inputs/inline-date/inline-date.scss
+++ b/src/components/inputs/inline-date/inline-date.scss
@@ -1,0 +1,17 @@
+@use '@carbon/colors';
+
+.boldedLabel label {
+  font-weight: 600;
+  color: colors.$black-100;
+}
+
+.errorLabel label {
+  color: colors.$red-60;
+  font-weight: 600;
+}
+
+.datetime {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}

--- a/src/components/inputs/inline-date/inline-date.test.tsx
+++ b/src/components/inputs/inline-date/inline-date.test.tsx
@@ -161,7 +161,7 @@ describe('dropdown input field', () => {
         value: '14cd2628-8a33-4b93-9c10-43989950bba0',
         formFieldNamespace: 'rfe-forms',
         formFieldPath: 'rfe-forms-patient-past-program',
-        obsDatetime: new Date("2024-05-16T03:00:00.000Z"),
+        obsDatetime: new Date("2024-05-16T00:00:00.000Z"),
       });
     });
   });

--- a/src/components/inputs/inline-date/inline-date.test.tsx
+++ b/src/components/inputs/inline-date/inline-date.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
+import dayjs from 'dayjs';
 import { type EncounterContext, FormContext } from '../../../form-context';
 import DropdownSelect from '../select/dropdown.component';
 import { type FormField } from '../../../types';
@@ -151,18 +152,16 @@ describe('dropdown input field', () => {
     const fightMalariaOption = screen.getByText('Fight Malaria Initiative');
     fireEvent.click(fightMalariaOption);
 
+    const testDate = dayjs('2024-05-17').toISOString();
     // test handle change
-    fireEvent.change(inlineDatePicker, { target: { value: new Date("2024-05-16T00:00:00.000Z") } });
+    fireEvent.change(inlineDatePicker, { target: { value: testDate } });
 
     await act(async () => {
-
-      expect(questionWithDateEnabled.meta.submission?.newValue).toEqual({
-        uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
-        value: '14cd2628-8a33-4b93-9c10-43989950bba0',
-        formFieldNamespace: 'rfe-forms',
-        formFieldPath: 'rfe-forms-patient-past-program',
-        obsDatetime: new Date("2024-05-16T00:00:00.000Z"),
-      });
+      const newValue = questionWithDateEnabled.meta.submission?.newValue;
+      const refinedDate = new Date(dayjs(testDate).toDate().getTime() - new Date(dayjs(testDate).toDate()).getTimezoneOffset() * 60000);
+      expect(newValue?.obsDatetime).toBeDefined();
+      expect(newValue).toHaveProperty('obsDatetime');
+      expect(newValue.obsDatetime).toEqual(refinedDate);
     });
   });
 });

--- a/src/components/inputs/inline-date/inline-date.test.tsx
+++ b/src/components/inputs/inline-date/inline-date.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Formik } from 'formik';
+import { type EncounterContext, FormContext } from '../../../form-context';
+import DropdownSelect from '../select/dropdown.component';
+import { type FormField } from '../../../types';
+import { ObsSubmissionHandler } from '../../../submission-handlers/obsHandler';
+import InlineDate from '../inline-date/inline-date.component';
+
+const question: FormField = {
+  label: 'Patient past program.',
+  type: 'obs',
+  questionOptions: {
+    rendering: 'select',
+    concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
+    answers: [
+      {
+        label: 'HIV Care and Treatment',
+        value: '6ddd933a-e65c-4f35-8884-c555b50c55e1',
+      },
+      {
+        label: 'Oncology Screening and Diagnosis Program',
+        value: '12f7be3d-fb5d-47dc-b5e3-56c501be80a6',
+      },
+      {
+        label: 'Fight Malaria Initiative',
+        value: '14cd2628-8a33-4b93-9c10-43989950bba0',
+      },
+    ],
+  },
+  meta: {},
+  id: 'patient-past-program',
+};
+
+const questionWithDateEnabled: FormField = {
+  label: 'Patient past program.',
+  type: 'obs',
+  questionOptions: {
+    rendering: 'select',
+    concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
+    showDate: "true",
+    answers: [
+      {
+        label: 'HIV Care and Treatment',
+        value: '6ddd933a-e65c-4f35-8884-c555b50c55e1',
+      },
+      {
+        label: 'Oncology Screening and Diagnosis Program',
+        value: '12f7be3d-fb5d-47dc-b5e3-56c501be80a6',
+      },
+      {
+        label: 'Fight Malaria Initiative',
+        value: '14cd2628-8a33-4b93-9c10-43989950bba0',
+      },
+    ],
+  },
+  meta: {},
+  id: 'patient-past-program',
+};
+
+const encounterContext: EncounterContext = {
+  patient: {
+    id: '833db896-c1f0-11eb-8529-0242ac130003',
+  },
+  location: {
+    uuid: '41e6e516-c1f0-11eb-8529-0242ac130003',
+  },
+  encounter: {
+    uuid: '873455da-3ec4-453c-b565-7c1fe35426be',
+    obs: [],
+  },
+  sessionMode: 'enter',
+  encounterDate: new Date(2020, 11, 29),
+  setEncounterDate: (value) => {},
+  encounterProvider: '2c95f6f5-788e-4e73-9079-5626911231fa',
+  setEncounterProvider: jest.fn,
+  setEncounterLocation: jest.fn,
+};
+
+const renderForm = (initialValues, questionObj) => {
+  render(
+    <Formik initialValues={initialValues} onSubmit={null}>
+      {(props) => (
+        <FormContext.Provider
+          value={{
+            values: props.values,
+            setFieldValue: props.setFieldValue,
+            setEncounterLocation: jest.fn(),
+            encounterContext: encounterContext,
+            fields: [questionObj],
+            isFieldInitializationComplete: true,
+            isSubmitting: false,
+            formFieldHandlers: { obs: ObsSubmissionHandler },
+          }}>
+          <DropdownSelect question={questionObj} onChange={jest.fn()} handler={ObsSubmissionHandler} />
+          {question.questionOptions.showDate === 'true' ? (
+          <div style={{ marginTop: '5px' }}>
+            <InlineDate question={question} setObsDateTime={jest.fn()} />
+          </div>
+          ) : null}
+
+        </FormContext.Provider>
+      )}
+    </Formik>,
+  );
+};
+
+const mockI18next = {
+  language: 'en',
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'i18next', {
+    value: mockI18next,
+  });
+});
+
+describe('dropdown input field', () => {
+  afterEach(() => {
+    // teardown
+    question.meta = {};
+  });
+
+  it('should not show the date picker when question does not have showDate as true', async () => {
+    await renderForm({}, question);
+
+    const inlineDatePicker = screen.queryByLabelText('custom-inline-date-picker');
+    await expect(inlineDatePicker).not.toBeInTheDocument();
+  });
+
+  it('should append an inline date picker when showDate is true', async () => {
+    questionWithDateEnabled.meta.previousValue = {
+      uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
+      person: '833db896-c1f0-11eb-8529-0242ac130003',
+      obsDatetime: encounterContext.encounterDate,
+      concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
+      location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
+      order: null,
+      groupMembers: [],
+      voided: false,
+      value: '6ddd933a-e65c-4f35-8884-c555b50c55e1',
+    };
+
+    await renderForm({ 'patient-past-program': questionWithDateEnabled.meta.previousValue.value }, questionWithDateEnabled);
+    const dropdownWidget = screen.getByRole('combobox', { name: /Patient past program./ });
+    const inlineDatePicker = screen.getByLabelText('custom-inline-date-picker');
+    expect(inlineDatePicker).toBeInTheDocument();
+
+    // input an option for the select
+    fireEvent.click(dropdownWidget);
+    const fightMalariaOption = screen.getByText('Fight Malaria Initiative');
+    fireEvent.click(fightMalariaOption);
+
+    // test handle change
+    fireEvent.change(inlineDatePicker, { target: { value: new Date("2024-05-16T00:00:00.000Z") } });
+
+    await act(async () => {
+
+      expect(questionWithDateEnabled.meta.submission?.newValue).toEqual({
+        uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
+        value: '14cd2628-8a33-4b93-9c10-43989950bba0',
+        formFieldNamespace: 'rfe-forms',
+        formFieldPath: 'rfe-forms-patient-past-program',
+        obsDatetime: new Date("2024-05-16T03:00:00.000Z"),
+      });
+    });
+  });
+});

--- a/src/components/inputs/multi-select/multi-select-component.test.tsx
+++ b/src/components/inputs/multi-select/multi-select-component.test.tsx
@@ -57,6 +57,16 @@ const renderForm = async () => {
   );
 };
 
+const mockI18next = {
+  language: 'en',
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'i18next', {
+    value: mockI18next,
+  });
+});
+
 describe('OHRIMultiSelect Component', () => {
   it('renders correctly', async () => {
     await renderForm();

--- a/src/components/inputs/multi-select/multi-select.component.tsx
+++ b/src/components/inputs/multi-select/multi-select.component.tsx
@@ -10,6 +10,8 @@ import { isInlineView } from '../../../utils/form-helper';
 import { isTrue } from '../../../utils/boolean-utils';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
+import InlineDate from '../inline-date/inline-date.component';
+
 import styles from './multi-select.scss';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
@@ -20,6 +22,7 @@ const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
     React.useContext(FormContext);
   const [counter, setCounter] = useState(0);
   const { errors, warnings, setErrors, setWarnings } = useFieldValidationResults(question);
+  const [obsDate, setObsDate] = useState<Date>();
 
   const selectOptions = question.questionOptions.answers
     .filter((answer) => !answer.isHidden)
@@ -55,8 +58,14 @@ const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
         : [previousValue.value];
       setFieldValue(question.id, previousValues);
       onChange(question.id, previousValues, setErrors, setWarnings);
-      handler?.handleFieldSubmission(question, previousValues, encounterContext);
-    }
+    question.value =
+      obsDate === undefined
+        ? handler?.handleFieldSubmission(question, previousValues, encounterContext)
+        : handler?.handleFieldSubmission(question, previousValues, {
+            ...encounterContext,
+            encounterDate: obsDate !== undefined ? obsDate : undefined,
+          });
+        }
   }, [previousValue]);
 
   const isInline = useMemo(() => {
@@ -118,6 +127,15 @@ const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
             <ValueEmpty />
           )}
         </div>
+        {question.questionOptions.showDate === 'true' ? (
+          <div style={{ marginTop: '5px' }}>
+            <InlineDate
+              question={question}
+              setObsDateTime={(value) => setObsDate(value)}
+              onChange={() => {}}
+            />
+          </div>
+        ) : null}
       </>
     )
   );

--- a/src/components/inputs/multi-select/multi-select.component.tsx
+++ b/src/components/inputs/multi-select/multi-select.component.tsx
@@ -49,7 +49,7 @@ const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
     });
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
-    handler?.handleFieldSubmission(question, value, encounterContext);
+    getQuestionValue({ obsDate, question, value, handler, encounterContext });
   };
 
   useEffect(() => {
@@ -59,13 +59,7 @@ const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
         : [previousValue.value];
       setFieldValue(question.id, previousValues);
       onChange(question.id, previousValues, setErrors, setWarnings);
-      question.value =
-        obsDate === undefined
-          ? handler?.handleFieldSubmission(question, previousValues, encounterContext)
-          : handler?.handleFieldSubmission(question, previousValues, {
-              ...encounterContext,
-              encounterDate: obsDate !== undefined ? obsDate : undefined,
-            });
+      getQuestionValue({ obsDate, question, value: previousValues, handler, encounterContext })
     }
   }, [previousValue]);
 

--- a/src/components/inputs/multi-select/multi-select.component.tsx
+++ b/src/components/inputs/multi-select/multi-select.component.tsx
@@ -11,9 +11,10 @@ import { isTrue } from '../../../utils/boolean-utils';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import InlineDate from '../inline-date/inline-date.component';
+import { getQuestionValue } from '../../../utils/common-utils';
+import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 import styles from './multi-select.scss';
-import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
   const { t } = useTranslation();
@@ -58,14 +59,14 @@ const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
         : [previousValue.value];
       setFieldValue(question.id, previousValues);
       onChange(question.id, previousValues, setErrors, setWarnings);
-    question.value =
-      obsDate === undefined
-        ? handler?.handleFieldSubmission(question, previousValues, encounterContext)
-        : handler?.handleFieldSubmission(question, previousValues, {
-            ...encounterContext,
-            encounterDate: obsDate !== undefined ? obsDate : undefined,
-          });
-        }
+      question.value =
+        obsDate === undefined
+          ? handler?.handleFieldSubmission(question, previousValues, encounterContext)
+          : handler?.handleFieldSubmission(question, previousValues, {
+              ...encounterContext,
+              encounterDate: obsDate !== undefined ? obsDate : undefined,
+            });
+    }
   }, [previousValue]);
 
   const isInline = useMemo(() => {
@@ -132,7 +133,6 @@ const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
             <InlineDate
               question={question}
               setObsDateTime={(value) => setObsDate(value)}
-              onChange={() => {}}
             />
           </div>
         ) : null}

--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -17,7 +17,7 @@ import { getQuestionValue } from '../../../utils/common-utils';
 import styles from './number.scss';
 
 const NumberField: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
-  const [field, meta] = useField(question.id);
+  const [field] = useField(question.id);
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
   const { t } = useTranslation();
   const { errors, warnings, setErrors, setWarnings } = useFieldValidationResults(question);

--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -96,9 +96,7 @@ const NumberField: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
             setObsDateTime={(value) => setObsDate(value)}
           />
         </div>
-      ) : (
-        ''
-      )}
+      ) : null}
     </Layer>
   );
 };

--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -12,6 +12,7 @@ import RequiredFieldLabel from '../../required-field-label/required-field-label.
 import InlineDate from '../inline-date/inline-date.component';
 import { useTranslation } from 'react-i18next';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
+import { getQuestionValue } from '../../../utils/common-utils';
 
 import styles from './number.scss';
 
@@ -33,13 +34,7 @@ const NumberField: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
     }
     if (previousValue !== field.value) {
       onChange(question.id, field.value, setErrors, setWarnings);
-      question.value =
-        obsDate === undefined
-          ? handler?.handleFieldSubmission(question, field?.value, encounterContext)
-          : handler?.handleFieldSubmission(question, field?.value, {
-              ...encounterContext,
-              encounterDate: obsDate !== undefined ? obsDate : undefined,
-            });
+      question.value = getQuestionValue({ obsDate, question, value: field?.value, handler, encounterContext });
     }
   };
 
@@ -99,7 +94,6 @@ const NumberField: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
           <InlineDate
             question={question}
             setObsDateTime={(value) => setObsDate(value)}
-            onChange={() => {}}
           />
         </div>
       ) : (

--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -34,7 +34,7 @@ const NumberField: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
     }
     if (previousValue !== field.value) {
       onChange(question.id, field.value, setErrors, setWarnings);
-      question.value = getQuestionValue({ obsDate, question, value: field?.value, handler, encounterContext });
+      getQuestionValue({ obsDate, question, value: field?.value, handler, encounterContext });
     }
   };
 

--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -9,9 +9,11 @@ import FieldValueView from '../../value/view/field-value-view.component';
 import { type FormFieldProps } from '../../../types';
 import { FormContext } from '../../../form-context';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
-import styles from './number.scss';
+import InlineDate from '../inline-date/inline-date.component';
 import { useTranslation } from 'react-i18next';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
+
+import styles from './number.scss';
 
 const NumberField: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
   const [field, meta] = useField(question.id);
@@ -84,6 +86,11 @@ const NumberField: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
         warnText={warnings[0]?.message}
         step={0.01}
       />
+      {question.questionOptions.showDate && (
+      <div style={{ marginTop: '5px' }}>
+      <InlineDate question={question} onChange={() => {}} handler={undefined} />
+    </div>
+  )}
     </Layer>
   );
 };

--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Layer, NumberInput } from '@carbon/react';
 import classNames from 'classnames';
 import { useField } from 'formik';
@@ -20,6 +20,7 @@ const NumberField: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
   const { t } = useTranslation();
   const { errors, warnings, setErrors, setWarnings } = useFieldValidationResults(question);
+  const [obsDate, setObsDate] = useState<Date>();
 
   field.onBlur = (event) => {
     if (event && event.target.value != field.value) {
@@ -32,7 +33,13 @@ const NumberField: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
     }
     if (previousValue !== field.value) {
       onChange(question.id, field.value, setErrors, setWarnings);
-      handler?.handleFieldSubmission(question, field.value, encounterContext);
+      question.value =
+        obsDate === undefined
+          ? handler?.handleFieldSubmission(question, field?.value, encounterContext)
+          : handler?.handleFieldSubmission(question, field?.value, {
+              ...encounterContext,
+              encounterDate: obsDate !== undefined ? obsDate : undefined,
+            });
     }
   };
 
@@ -86,11 +93,18 @@ const NumberField: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
         warnText={warnings[0]?.message}
         step={0.01}
       />
-      {question.questionOptions.showDate && (
-      <div style={{ marginTop: '5px' }}>
-      <InlineDate question={question} onChange={() => {}} handler={undefined} />
-    </div>
-  )}
+
+      {question.questionOptions.showDate === 'true' ? (
+        <div style={{ marginTop: '5px' }}>
+          <InlineDate
+            question={question}
+            setObsDateTime={(value) => setObsDate(value)}
+            onChange={() => {}}
+          />
+        </div>
+      ) : (
+        ''
+      )}
     </Layer>
   );
 };

--- a/src/components/inputs/radio/radio.component.tsx
+++ b/src/components/inputs/radio/radio.component.tsx
@@ -9,6 +9,8 @@ import { isInlineView } from '../../../utils/form-helper';
 import { isEmpty } from '../../../validators/form-validator';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
+import InlineDate from '../inline-date/inline-date.component';
+
 import styles from './radio.scss';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
@@ -79,6 +81,11 @@ const Radio: React.FC<FormFieldProps> = ({ question, onChange, handler, previous
             </div>
           </div>
         )}
+        {question.questionOptions.showDate === 'true' ? (
+          <div style={{ marginTop: '5px' }}>
+            <InlineDate question={question} onChange={() => {}} handler={undefined} />
+          </div>
+        ) : null}
       </FormGroup>
     )
   );

--- a/src/components/inputs/radio/radio.component.tsx
+++ b/src/components/inputs/radio/radio.component.tsx
@@ -11,6 +11,7 @@ import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import InlineDate from '../inline-date/inline-date.component';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
+import { getQuestionValue } from '../../../utils/common-utils';
 
 import styles from './radio.scss';
 
@@ -24,13 +25,7 @@ const Radio: React.FC<FormFieldProps> = ({ question, onChange, handler, previous
   const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
-    question.value =
-      obsDate === undefined
-        ? handler?.handleFieldSubmission(question, value?.name, encounterContext)
-        : handler?.handleFieldSubmission(question, value?.name, {
-            ...encounterContext,
-            encounterDate: obsDate !== undefined ? obsDate : undefined,
-          });
+    question.value = getQuestionValue({ obsDate, question, value: value?.name, handler, encounterContext });
   };
 
   useEffect(() => {
@@ -38,13 +33,7 @@ const Radio: React.FC<FormFieldProps> = ({ question, onChange, handler, previous
       const { value } = previousValue;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, setWarnings);
-      question.value =
-        obsDate === undefined
-          ? handler?.handleFieldSubmission(question, value, encounterContext)
-          : handler?.handleFieldSubmission(question, value, {
-              ...encounterContext,
-              encounterDate: obsDate !== undefined ? obsDate : undefined,
-            });
+      question.value = getQuestionValue({ obsDate, question, value, handler, encounterContext });
     }
   }, [previousValue]);
 
@@ -99,7 +88,6 @@ const Radio: React.FC<FormFieldProps> = ({ question, onChange, handler, previous
             <InlineDate
               question={question}
               setObsDateTime={(value) => setObsDate(value)}
-              onChange={() => {}}
             />
           </div>
         ) : null}

--- a/src/components/inputs/radio/radio.component.tsx
+++ b/src/components/inputs/radio/radio.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FormGroup, RadioButtonGroup, RadioButton } from '@carbon/react';
 import { type FormFieldProps } from '../../../types';
@@ -10,20 +10,27 @@ import { isEmpty } from '../../../validators/form-validator';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import InlineDate from '../inline-date/inline-date.component';
+import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 import styles from './radio.scss';
-import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 const Radio: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
   const [field, meta] = useField(question.id);
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
   const { t } = useTranslation();
   const { errors, warnings, setErrors, setWarnings } = useFieldValidationResults(question);
+  const [obsDate, setObsDate] = useState<Date>();
 
   const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
-    handler?.handleFieldSubmission(question, value, encounterContext);
+    question.value =
+      obsDate === undefined
+        ? handler?.handleFieldSubmission(question, value, encounterContext)
+        : handler?.handleFieldSubmission(question, value, {
+            ...encounterContext,
+            encounterDate: obsDate !== undefined ? obsDate : undefined,
+          });
   };
 
   useEffect(() => {
@@ -31,7 +38,13 @@ const Radio: React.FC<FormFieldProps> = ({ question, onChange, handler, previous
       const { value } = previousValue;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, setWarnings);
-      handler?.handleFieldSubmission(question, value, encounterContext);
+      question.value =
+        obsDate === undefined
+          ? handler?.handleFieldSubmission(question, value, encounterContext)
+          : handler?.handleFieldSubmission(question, value, {
+              ...encounterContext,
+              encounterDate: obsDate !== undefined ? obsDate : undefined,
+            });
     }
   }, [previousValue]);
 
@@ -83,7 +96,11 @@ const Radio: React.FC<FormFieldProps> = ({ question, onChange, handler, previous
         )}
         {question.questionOptions.showDate === 'true' ? (
           <div style={{ marginTop: '5px' }}>
-            <InlineDate question={question} onChange={() => {}} handler={undefined} />
+            <InlineDate
+              question={question}
+              setObsDateTime={(value) => setObsDate(value)}
+              onChange={() => {}}
+            />
           </div>
         ) : null}
       </FormGroup>

--- a/src/components/inputs/radio/radio.component.tsx
+++ b/src/components/inputs/radio/radio.component.tsx
@@ -26,8 +26,8 @@ const Radio: React.FC<FormFieldProps> = ({ question, onChange, handler, previous
     onChange(question.id, value, setErrors, setWarnings);
     question.value =
       obsDate === undefined
-        ? handler?.handleFieldSubmission(question, value, encounterContext)
-        : handler?.handleFieldSubmission(question, value, {
+        ? handler?.handleFieldSubmission(question, value?.name, encounterContext)
+        : handler?.handleFieldSubmission(question, value?.name, {
             ...encounterContext,
             encounterDate: obsDate !== undefined ? obsDate : undefined,
           });

--- a/src/components/inputs/radio/radio.component.tsx
+++ b/src/components/inputs/radio/radio.component.tsx
@@ -25,7 +25,7 @@ const Radio: React.FC<FormFieldProps> = ({ question, onChange, handler, previous
   const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
-    question.value = getQuestionValue({ obsDate, question, value: value?.name, handler, encounterContext });
+    getQuestionValue({ obsDate, question, value, handler, encounterContext });
   };
 
   useEffect(() => {
@@ -33,7 +33,7 @@ const Radio: React.FC<FormFieldProps> = ({ question, onChange, handler, previous
       const { value } = previousValue;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, setWarnings);
-      question.value = getQuestionValue({ obsDate, question, value, handler, encounterContext });
+      getQuestionValue({ obsDate, question, value, handler, encounterContext });
     }
   }, [previousValue]);
 

--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -25,12 +25,12 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
     question.value =
-        obsDate === undefined
-          ? handler?.handleFieldSubmission(question, value, encounterContext)
-          : handler?.handleFieldSubmission(question, value, {
-              ...encounterContext,
-              encounterDate: obsDate !== undefined ? obsDate : undefined,
-            });
+      obsDate === undefined
+        ? handler?.handleFieldSubmission(question, value?.name, encounterContext)
+        : handler?.handleFieldSubmission(question, value?.name, {
+            ...encounterContext,
+            encounterDate: obsDate !== undefined ? obsDate : undefined,
+          });
   };
 
   useEffect(() => {

--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dropdown as DropdownInput, Layer } from '@carbon/react';
 import { useField } from 'formik';
@@ -19,11 +19,18 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
   const [field, meta] = useField(question.id);
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
   const { errors, warnings, setErrors, setWarnings } = useFieldValidationResults(question);
+  const [obsDate, setObsDate] = useState<Date>();
 
   const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
-    handler?.handleFieldSubmission(question, value, encounterContext);
+    question.value =
+        obsDate === undefined
+          ? handler?.handleFieldSubmission(question, value, encounterContext)
+          : handler?.handleFieldSubmission(question, value, {
+              ...encounterContext,
+              encounterDate: obsDate !== undefined ? obsDate : undefined,
+            });
   };
 
   useEffect(() => {
@@ -31,7 +38,13 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
       const { value } = previousValue;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, setWarnings);
-      handler?.handleFieldSubmission(question, value, encounterContext);
+      question.value =
+        obsDate === undefined
+          ? handler?.handleFieldSubmission(question, value, encounterContext)
+          : handler?.handleFieldSubmission(question, value, {
+              ...encounterContext,
+              encounterDate: obsDate !== undefined ? obsDate : undefined,
+            });
     }
   }, [previousValue]);
 
@@ -79,11 +92,15 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
             warn={warnings.length > 0}
             warnText={warnings[0]?.message}
           />
-          {question.questionOptions.showDate && (
+          {question.questionOptions.showDate ? (
           <div style={{ marginTop: '5px' }}>
-          <InlineDate question={question} onChange={() => {}} handler={undefined} />
-        </div>
-  )}
+            <InlineDate
+              question={question}
+              setObsDateTime={(value) => setObsDate(value)}
+              onChange={() => {}}
+            />
+          </div>
+          ) : null}
         </Layer>
       </div>
     )

--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -25,7 +25,7 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
   const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
-    question.value = getQuestionValue({ obsDate, question, value: value?.name, handler, encounterContext });
+    question.value = getQuestionValue({ obsDate, question, value, handler, encounterContext });
   };
 
   useEffect(() => {

--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -81,7 +81,7 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
             warn={warnings.length > 0}
             warnText={warnings[0]?.message}
           />
-          {question.questionOptions.showDate ? (
+          {question.questionOptions.showDate === 'true' ? (
           <div style={{ marginTop: '5px' }}>
             <InlineDate
               question={question}

--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -25,7 +25,7 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
   const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
-    question.value = getQuestionValue({ obsDate, question, value, handler, encounterContext });
+    getQuestionValue({ obsDate, question, value, handler, encounterContext });
   };
 
   useEffect(() => {
@@ -33,7 +33,7 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
       const { value } = previousValue;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, setWarnings);
-      question.value = getQuestionValue({ obsDate, question, value, handler, encounterContext });
+      getQuestionValue({ obsDate, question, value, handler, encounterContext });
     }
   }, [previousValue]);
 

--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -10,9 +10,10 @@ import { type FormFieldProps } from '../../../types';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import InlineDate from '../inline-date/inline-date.component';
+import { getQuestionValue } from '../../../utils/common-utils';
+import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 import styles from './dropdown.scss';
-import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
   const { t } = useTranslation();
@@ -24,13 +25,7 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
   const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
-    question.value =
-      obsDate === undefined
-        ? handler?.handleFieldSubmission(question, value?.name, encounterContext)
-        : handler?.handleFieldSubmission(question, value?.name, {
-            ...encounterContext,
-            encounterDate: obsDate !== undefined ? obsDate : undefined,
-          });
+    question.value = getQuestionValue({ obsDate, question, value: value?.name, handler, encounterContext });
   };
 
   useEffect(() => {
@@ -38,13 +33,7 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
       const { value } = previousValue;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, setWarnings);
-      question.value =
-        obsDate === undefined
-          ? handler?.handleFieldSubmission(question, value, encounterContext)
-          : handler?.handleFieldSubmission(question, value, {
-              ...encounterContext,
-              encounterDate: obsDate !== undefined ? obsDate : undefined,
-            });
+      question.value = getQuestionValue({ obsDate, question, value, handler, encounterContext });
     }
   }, [previousValue]);
 
@@ -97,7 +86,6 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
             <InlineDate
               question={question}
               setObsDateTime={(value) => setObsDate(value)}
-              onChange={() => {}}
             />
           </div>
           ) : null}

--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -9,6 +9,8 @@ import { FormContext } from '../../../form-context';
 import { type FormFieldProps } from '../../../types';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
+import InlineDate from '../inline-date/inline-date.component';
+
 import styles from './dropdown.scss';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
@@ -77,6 +79,11 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
             warn={warnings.length > 0}
             warnText={warnings[0]?.message}
           />
+          {question.questionOptions.showDate && (
+          <div style={{ marginTop: '5px' }}>
+          <InlineDate question={question} onChange={() => {}} handler={undefined} />
+        </div>
+  )}
         </Layer>
       </div>
     )

--- a/src/components/inputs/select/dropdown.test.tsx
+++ b/src/components/inputs/select/dropdown.test.tsx
@@ -72,6 +72,16 @@ const renderForm = (initialValues) => {
   );
 };
 
+const mockI18next = {
+  language: 'en',
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'i18next', {
+    value: mockI18next,
+  });
+});
+
 describe('dropdown input field', () => {
   afterEach(() => {
     // teardown

--- a/src/components/inputs/select/dropdown.test.tsx
+++ b/src/components/inputs/select/dropdown.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { type EncounterContext, FormContext } from '../../../form-context';
 import Dropdown from './dropdown.component';
 import { type FormField } from '../../../types';
 import { ObsSubmissionHandler } from '../../../submission-handlers/obsHandler';
+import InlineDate from '../inline-date/inline-date.component';
 
 const question: FormField = {
   label: 'Patient past program.',
@@ -12,6 +13,32 @@ const question: FormField = {
   questionOptions: {
     rendering: 'select',
     concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
+    answers: [
+      {
+        label: 'HIV Care and Treatment',
+        value: '6ddd933a-e65c-4f35-8884-c555b50c55e1',
+      },
+      {
+        label: 'Oncology Screening and Diagnosis Program',
+        value: '12f7be3d-fb5d-47dc-b5e3-56c501be80a6',
+      },
+      {
+        label: 'Fight Malaria Initiative',
+        value: '14cd2628-8a33-4b93-9c10-43989950bba0',
+      },
+    ],
+  },
+  meta: {},
+  id: 'patient-past-program',
+};
+
+const questionWithDateEnabled: FormField = {
+  label: 'Patient past program.',
+  type: 'obs',
+  questionOptions: {
+    rendering: 'select',
+    concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
+    showDate: "true",
     answers: [
       {
         label: 'HIV Care and Treatment',
@@ -50,7 +77,7 @@ const encounterContext: EncounterContext = {
   setEncounterLocation: jest.fn,
 };
 
-const renderForm = (initialValues) => {
+const renderForm = (initialValues, questionObj) => {
   render(
     <Formik initialValues={initialValues} onSubmit={null}>
       {(props) => (
@@ -60,12 +87,12 @@ const renderForm = (initialValues) => {
             setFieldValue: props.setFieldValue,
             setEncounterLocation: jest.fn(),
             encounterContext: encounterContext,
-            fields: [question],
+            fields: [questionObj],
             isFieldInitializationComplete: true,
             isSubmitting: false,
             formFieldHandlers: { obs: ObsSubmissionHandler },
           }}>
-          <Dropdown question={question} onChange={jest.fn()} handler={ObsSubmissionHandler} />
+          <Dropdown question={questionObj} onChange={jest.fn()} handler={ObsSubmissionHandler} />
         </FormContext.Provider>
       )}
     </Formik>,
@@ -89,7 +116,7 @@ describe('dropdown input field', () => {
   });
 
   it('should record new obs', async () => {
-    await renderForm({});
+    await renderForm({}, question);
     // setup
     const dropdownWidget = screen.getByRole('combobox', { name: /Patient past program./ });
 
@@ -127,7 +154,7 @@ describe('dropdown input field', () => {
       voided: false,
       value: '6ddd933a-e65c-4f35-8884-c555b50c55e1',
     };
-    await renderForm({ 'patient-past-program': question.meta.previousValue.value });
+    await renderForm({ 'patient-past-program': question.meta.previousValue.value }, question);
     const dropdownWidget = screen.getByRole('combobox', { name: /Patient past program./ });
 
     // do some edits
@@ -144,5 +171,47 @@ describe('dropdown input field', () => {
         formFieldPath: 'rfe-forms-patient-past-program',
       });
     });
+
+    // date shouldn't be there
+    const inlineDatePicker = screen.queryByLabelText('custom-inline-date-picker');
+    await expect(inlineDatePicker).not.toBeInTheDocument();
+  });
+
+  it('should append an inline date picker when showDate is true', async () => {
+    questionWithDateEnabled.meta.previousValue = {
+      uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
+      person: '833db896-c1f0-11eb-8529-0242ac130003',
+      obsDatetime: encounterContext.encounterDate,
+      concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
+      location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
+      order: null,
+      groupMembers: [],
+      voided: false,
+      value: '6ddd933a-e65c-4f35-8884-c555b50c55e1',
+    };
+
+    await renderForm({ 'patient-past-program': questionWithDateEnabled.meta.previousValue.value }, questionWithDateEnabled);
+    const dropdownWidget = screen.getByRole('combobox', { name: /Patient past program./ });
+    const inlineDatePicker = screen.getByLabelText('custom-inline-date-picker');
+    expect(inlineDatePicker).toBeInTheDocument();
+
+    // choose an option
+    fireEvent.click(dropdownWidget);
+    const fightMalariaOption = screen.getByText('Fight Malaria Initiative');
+    fireEvent.click(fightMalariaOption);
+
+    // test handle change
+    fireEvent.change(inlineDatePicker, { target: { value: new Date('2022-05-17') } });
+
+    await act(async () => {
+      expect(questionWithDateEnabled.meta.submission?.newValue).toEqual({
+        uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
+        value: '14cd2628-8a33-4b93-9c10-43989950bba0',
+        formFieldNamespace: 'rfe-forms',
+        formFieldPath: 'rfe-forms-patient-past-program',
+        obsDatetime: new Date('2022-05-17T03:00:00.000Z'),
+      });
+    });
+
   });
 });

--- a/src/components/inputs/select/dropdown.test.tsx
+++ b/src/components/inputs/select/dropdown.test.tsx
@@ -176,42 +176,4 @@ describe('dropdown input field', () => {
     const inlineDatePicker = screen.queryByLabelText('custom-inline-date-picker');
     await expect(inlineDatePicker).not.toBeInTheDocument();
   });
-
-  it('should append an inline date picker when showDate is true', async () => {
-    questionWithDateEnabled.meta.previousValue = {
-      uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
-      person: '833db896-c1f0-11eb-8529-0242ac130003',
-      obsDatetime: encounterContext.encounterDate,
-      concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
-      location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
-      order: null,
-      groupMembers: [],
-      voided: false,
-      value: '6ddd933a-e65c-4f35-8884-c555b50c55e1',
-    };
-
-    await renderForm({ 'patient-past-program': questionWithDateEnabled.meta.previousValue.value }, questionWithDateEnabled);
-    const dropdownWidget = screen.getByRole('combobox', { name: /Patient past program./ });
-    const inlineDatePicker = screen.getByLabelText('custom-inline-date-picker');
-    expect(inlineDatePicker).toBeInTheDocument();
-
-    // choose an option
-    fireEvent.click(dropdownWidget);
-    const fightMalariaOption = screen.getByText('Fight Malaria Initiative');
-    fireEvent.click(fightMalariaOption);
-
-    // test handle change
-    fireEvent.change(inlineDatePicker, { target: { value: new Date('2022-05-17') } });
-
-    await act(async () => {
-      expect(questionWithDateEnabled.meta.submission?.newValue).toEqual({
-        uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
-        value: '14cd2628-8a33-4b93-9c10-43989950bba0',
-        formFieldNamespace: 'rfe-forms',
-        formFieldPath: 'rfe-forms-patient-past-program',
-        obsDatetime: new Date('2022-05-17T03:00:00.000Z'),
-      });
-    });
-
-  });
 });

--- a/src/components/inputs/text-area/text-area.component.tsx
+++ b/src/components/inputs/text-area/text-area.component.tsx
@@ -9,6 +9,8 @@ import { FormContext } from '../../../form-context';
 import { type FormFieldProps } from '../../../types';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
+import InlineDate from '../inline-date/inline-date.component';
+
 import styles from './text-area.scss';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
@@ -72,7 +74,13 @@ const TextArea: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
             warn={warnings.length > 0}
             warnText={warnings[0]?.message}
           />
+          {question.questionOptions.showDate && (
+          <div style={{ marginTop: '5px' }}>
+          <InlineDate question={question} onChange={() => {}} handler={undefined} />
+        </div>
+  )}
         </Layer>
+
       </div>
     )
   );

--- a/src/components/inputs/text-area/text-area.component.tsx
+++ b/src/components/inputs/text-area/text-area.component.tsx
@@ -11,6 +11,7 @@ import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import InlineDate from '../inline-date/inline-date.component';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
+import { getQuestionValue } from '../../../utils/common-utils';
 
 import styles from './text-area.scss';
 
@@ -28,13 +29,7 @@ const TextArea: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
     }
     if (previousValue !== field.value) {
       onChange(question.id, field.value, setErrors, setWarnings);
-      question.value =
-        obsDate === undefined
-          ? handler?.handleFieldSubmission(question, field?.value, encounterContext)
-          : handler?.handleFieldSubmission(question, field?.value, {
-              ...encounterContext,
-              encounterDate: obsDate !== undefined ? obsDate : undefined,
-            });
+      question.value = getQuestionValue({ obsDate, question, value: field?.value, handler, encounterContext });
     }
   };
 
@@ -86,7 +81,6 @@ const TextArea: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
             <InlineDate
               question={question}
               setObsDateTime={(value) => setObsDate(value)}
-              onChange={() => {}}
             />
           </div>
         ) : null}

--- a/src/components/inputs/text-area/text-area.component.tsx
+++ b/src/components/inputs/text-area/text-area.component.tsx
@@ -17,7 +17,7 @@ import styles from './text-area.scss';
 
 const TextArea: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue: previousValueProp }) => {
   const { t } = useTranslation();
-  const [field, meta] = useField(question.id);
+  const [field] = useField(question.id);
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
   const [previousValue, setPreviousValue] = useState();
   const { errors, warnings, setErrors, setWarnings } = useFieldValidationResults(question);
@@ -29,7 +29,7 @@ const TextArea: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
     }
     if (previousValue !== field.value) {
       onChange(question.id, field.value, setErrors, setWarnings);
-      question.value = getQuestionValue({ obsDate, question, value: field?.value, handler, encounterContext });
+      getQuestionValue({ obsDate, question, value: field?.value, handler, encounterContext });
     }
   };
 

--- a/src/components/inputs/text-area/text-area.component.tsx
+++ b/src/components/inputs/text-area/text-area.component.tsx
@@ -10,9 +10,9 @@ import { type FormFieldProps } from '../../../types';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import InlineDate from '../inline-date/inline-date.component';
+import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 import styles from './text-area.scss';
-import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 const TextArea: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue: previousValueProp }) => {
   const { t } = useTranslation();
@@ -20,6 +20,7 @@ const TextArea: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
   const [previousValue, setPreviousValue] = useState();
   const { errors, warnings, setErrors, setWarnings } = useFieldValidationResults(question);
+  const [obsDate, setObsDate] = useState<Date>();
 
   field.onBlur = () => {
     if (field.value && question.unspecified) {
@@ -27,7 +28,13 @@ const TextArea: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
     }
     if (previousValue !== field.value) {
       onChange(question.id, field.value, setErrors, setWarnings);
-      handler?.handleFieldSubmission(question, field.value, encounterContext);
+      question.value =
+        obsDate === undefined
+          ? handler?.handleFieldSubmission(question, field?.value, encounterContext)
+          : handler?.handleFieldSubmission(question, field?.value, {
+              ...encounterContext,
+              encounterDate: obsDate !== undefined ? obsDate : undefined,
+            });
     }
   };
 
@@ -74,13 +81,16 @@ const TextArea: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
             warn={warnings.length > 0}
             warnText={warnings[0]?.message}
           />
-          {question.questionOptions.showDate && (
+          {question.questionOptions.showDate ? (
           <div style={{ marginTop: '5px' }}>
-          <InlineDate question={question} onChange={() => {}} handler={undefined} />
-        </div>
-  )}
+            <InlineDate
+              question={question}
+              setObsDateTime={(value) => setObsDate(value)}
+              onChange={() => {}}
+            />
+          </div>
+        ) : null}
         </Layer>
-
       </div>
     )
   );

--- a/src/components/inputs/text/text.component.tsx
+++ b/src/components/inputs/text/text.component.tsx
@@ -10,15 +10,16 @@ import { isInlineView } from '../../../utils/form-helper';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import InlineDate from '../inline-date/inline-date.component';
+import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 import styles from './text.scss';
-import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 const TextField: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
   const { t } = useTranslation();
   const [field] = useField(question.id);
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
   const { errors, warnings, setErrors, setWarnings } = useFieldValidationResults(question);
+  const [obsDate, setObsDate] = useState<Date>();
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
@@ -35,7 +36,13 @@ const TextField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
     }
     if (previousValue !== field.value) {
       onChange(question.id, field.value, setErrors, setWarnings);
-      handler?.handleFieldSubmission(question, field.value, encounterContext);
+      question.value =
+        obsDate === undefined
+          ? handler?.handleFieldSubmission(question, field?.value, encounterContext)
+          : handler?.handleFieldSubmission(question, field?.value, {
+              ...encounterContext,
+              encounterDate: obsDate !== undefined ? obsDate : undefined,
+            });
     }
   };
 
@@ -80,11 +87,15 @@ const TextField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
             />
           </Layer>
         </div>
-        {question.questionOptions.showDate && (
+        {question.questionOptions.showDate === 'true' ? (
           <div style={{ marginTop: '5px' }}>
-            <InlineDate question={question} onChange={() => {}} handler={undefined} />
+            <InlineDate
+              question={question}
+              setObsDateTime={(value) => setObsDate(value)}
+              onChange={() => {}}
+            />
           </div>
-        )}
+        ) : null}
       </>
     )
   );

--- a/src/components/inputs/text/text.component.tsx
+++ b/src/components/inputs/text/text.component.tsx
@@ -9,6 +9,8 @@ import { isTrue } from '../../../utils/boolean-utils';
 import { isInlineView } from '../../../utils/form-helper';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
+import InlineDate from '../inline-date/inline-date.component';
+
 import styles from './text.scss';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
@@ -78,6 +80,11 @@ const TextField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
             />
           </Layer>
         </div>
+        {question.questionOptions.showDate && (
+          <div style={{ marginTop: '5px' }}>
+            <InlineDate question={question} onChange={() => {}} handler={undefined} />
+          </div>
+        )}
       </>
     )
   );

--- a/src/components/inputs/text/text.component.tsx
+++ b/src/components/inputs/text/text.component.tsx
@@ -37,7 +37,7 @@ const TextField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
     }
     if (previousValue !== field.value) {
       onChange(question.id, field.value, setErrors, setWarnings);
-      question.value = getQuestionValue({ obsDate, question, value: field?.value, handler, encounterContext });
+      getQuestionValue({ obsDate, question, value: field?.value, handler, encounterContext });
     }
   };
 

--- a/src/components/inputs/text/text.component.tsx
+++ b/src/components/inputs/text/text.component.tsx
@@ -11,6 +11,7 @@ import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import InlineDate from '../inline-date/inline-date.component';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
+import { getQuestionValue } from '../../../utils/common-utils';
 
 import styles from './text.scss';
 
@@ -36,13 +37,7 @@ const TextField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
     }
     if (previousValue !== field.value) {
       onChange(question.id, field.value, setErrors, setWarnings);
-      question.value =
-        obsDate === undefined
-          ? handler?.handleFieldSubmission(question, field?.value, encounterContext)
-          : handler?.handleFieldSubmission(question, field?.value, {
-              ...encounterContext,
-              encounterDate: obsDate !== undefined ? obsDate : undefined,
-            });
+      question.value = getQuestionValue({ obsDate, question, value: field?.value, handler, encounterContext });
     }
   };
 
@@ -92,7 +87,6 @@ const TextField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
             <InlineDate
               question={question}
               setObsDateTime={(value) => setObsDate(value)}
-              onChange={() => {}}
             />
           </div>
         ) : null}

--- a/src/components/inputs/toggle/toggle.component.tsx
+++ b/src/components/inputs/toggle/toggle.component.tsx
@@ -8,8 +8,10 @@ import { isInlineView } from '../../../utils/form-helper';
 import FieldValueView from '../../value/view/field-value-view.component';
 import { isEmpty } from '../../../validators/form-validator';
 import { booleanConceptToBoolean } from '../../../utils/common-expression-helpers';
-import styles from './toggle.scss';
 import { useTranslation } from 'react-i18next';
+import InlineDate from '../inline-date/inline-date.component';
+
+import styles from './toggle.scss';
 
 const Toggle: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
   const { t } = useTranslation();
@@ -67,6 +69,11 @@ const Toggle: React.FC<FormFieldProps> = ({ question, onChange, handler, previou
           disabled={question.disabled}
           readOnly={question.readonly}
         />
+        {question.questionOptions.showDate && (
+          <div style={{ marginTop: '5px' }}>
+            <InlineDate question={question} onChange={() => {}} handler={undefined} />
+          </div>
+        )}
       </div>
     )
   );

--- a/src/components/inputs/toggle/toggle.component.tsx
+++ b/src/components/inputs/toggle/toggle.component.tsx
@@ -16,20 +16,21 @@ import styles from './toggle.scss';
 
 const Toggle: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
   const { t } = useTranslation();
-  const [field, meta] = useField(question.id);
+  const [field] = useField(question.id);
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
   const [obsDate, setObsDate] = useState<Date>();
 
   const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, null, null);
+    getQuestionValue({ obsDate, question, value, handler, encounterContext });
   };
 
   useEffect(() => {
     // The toogle input doesn't support blank values
     // by default, the value should be false
-    if (!question.value && encounterContext.sessionMode == 'enter') {
-      question.value = getQuestionValue({ obsDate, question, value: field.value ?? false, handler, encounterContext });
+    if (!question.meta?.previousValue && encounterContext.sessionMode == 'enter') {
+      getQuestionValue({ obsDate, question, value: field.value ?? false, handler, encounterContext });
     }
   }, []);
 
@@ -38,13 +39,7 @@ const Toggle: React.FC<FormFieldProps> = ({ question, onChange, handler, previou
       const value = booleanConceptToBoolean(previousValue);
       setFieldValue(question.id, value);
       onChange(question.id, value, null, null);
-      question.value =
-        obsDate === undefined
-          ? handler?.handleFieldSubmission(question, value, encounterContext)
-          : handler?.handleFieldSubmission(question, value, {
-              ...encounterContext,
-              encounterDate: obsDate !== undefined ? obsDate : undefined,
-            });
+      getQuestionValue({ obsDate, question, value, handler, encounterContext });
     }
   }, [previousValue]);
 

--- a/src/components/inputs/toggle/toggle.component.tsx
+++ b/src/components/inputs/toggle/toggle.component.tsx
@@ -78,9 +78,7 @@ const Toggle: React.FC<FormFieldProps> = ({ question, onChange, handler, previou
               setObsDateTime={(value) => setObsDate(value)}
             />
           </div>
-        ) : (
-          ''
-        )}
+        ) : null}
       </div>
     )
   );

--- a/src/components/inputs/toggle/toggle.component.tsx
+++ b/src/components/inputs/toggle/toggle.component.tsx
@@ -10,7 +10,7 @@ import { isEmpty } from '../../../validators/form-validator';
 import { booleanConceptToBoolean } from '../../../utils/common-expression-helpers';
 import { useTranslation } from 'react-i18next';
 import InlineDate from '../inline-date/inline-date.component';
-import { ObsSubmissionHandler } from '../../../submission-handlers/base-handlers';
+import { getQuestionValue } from '../../../utils/common-utils';
 
 import styles from './toggle.scss';
 
@@ -18,32 +18,18 @@ const Toggle: React.FC<FormFieldProps> = ({ question, onChange, handler, previou
   const { t } = useTranslation();
   const [field, meta] = useField(question.id);
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
-  const [conceptName, setConceptName] = useState('Loading...');
   const [obsDate, setObsDate] = useState<Date>();
 
   const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, null, null);
-    question.value =
-        obsDate === undefined
-          ? handler?.handleFieldSubmission(question, value, encounterContext)
-          : handler?.handleFieldSubmission(question, value, {
-              ...encounterContext,
-              encounterDate: obsDate !== undefined ? obsDate : undefined,
-            });
   };
 
   useEffect(() => {
     // The toogle input doesn't support blank values
     // by default, the value should be false
-    if (!question.meta?.previousValue && encounterContext.sessionMode == 'enter') {
-      question.value =
-        obsDate === undefined
-          ? handler?.handleFieldSubmission(question, field.value ?? false, encounterContext)
-          : handler?.handleFieldSubmission(question, field.value ?? false, {
-              ...encounterContext,
-              encounterDate: obsDate !== undefined ? obsDate : undefined,
-            });
+    if (!question.value && encounterContext.sessionMode == 'enter') {
+      question.value = getQuestionValue({ obsDate, question, value: field.value ?? false, handler, encounterContext });
     }
   }, []);
 
@@ -95,8 +81,6 @@ const Toggle: React.FC<FormFieldProps> = ({ question, onChange, handler, previou
             <InlineDate
               question={question}
               setObsDateTime={(value) => setObsDate(value)}
-              onChange={() => {}}
-              handler={ObsSubmissionHandler}
             />
           </div>
         ) : (

--- a/src/components/inputs/toggle/toggle.component.tsx
+++ b/src/components/inputs/toggle/toggle.component.tsx
@@ -10,6 +10,7 @@ import { isEmpty } from '../../../validators/form-validator';
 import { booleanConceptToBoolean } from '../../../utils/common-expression-helpers';
 import { useTranslation } from 'react-i18next';
 import InlineDate from '../inline-date/inline-date.component';
+import { ObsSubmissionHandler } from '../../../submission-handlers/base-handlers';
 
 import styles from './toggle.scss';
 
@@ -17,18 +18,32 @@ const Toggle: React.FC<FormFieldProps> = ({ question, onChange, handler, previou
   const { t } = useTranslation();
   const [field, meta] = useField(question.id);
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
+  const [conceptName, setConceptName] = useState('Loading...');
+  const [obsDate, setObsDate] = useState<Date>();
 
   const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, null, null);
-    handler?.handleFieldSubmission(question, value, encounterContext);
+    question.value =
+        obsDate === undefined
+          ? handler?.handleFieldSubmission(question, value, encounterContext)
+          : handler?.handleFieldSubmission(question, value, {
+              ...encounterContext,
+              encounterDate: obsDate !== undefined ? obsDate : undefined,
+            });
   };
 
   useEffect(() => {
     // The toogle input doesn't support blank values
     // by default, the value should be false
     if (!question.meta?.previousValue && encounterContext.sessionMode == 'enter') {
-      handler?.handleFieldSubmission(question, field.value ?? false, encounterContext);
+      question.value =
+        obsDate === undefined
+          ? handler?.handleFieldSubmission(question, field.value ?? false, encounterContext)
+          : handler?.handleFieldSubmission(question, field.value ?? false, {
+              ...encounterContext,
+              encounterDate: obsDate !== undefined ? obsDate : undefined,
+            });
     }
   }, []);
 
@@ -37,7 +52,13 @@ const Toggle: React.FC<FormFieldProps> = ({ question, onChange, handler, previou
       const value = booleanConceptToBoolean(previousValue);
       setFieldValue(question.id, value);
       onChange(question.id, value, null, null);
-      handler?.handleFieldSubmission(question, value, encounterContext);
+      question.value =
+        obsDate === undefined
+          ? handler?.handleFieldSubmission(question, value, encounterContext)
+          : handler?.handleFieldSubmission(question, value, {
+              ...encounterContext,
+              encounterDate: obsDate !== undefined ? obsDate : undefined,
+            });
     }
   }, [previousValue]);
 
@@ -69,10 +90,17 @@ const Toggle: React.FC<FormFieldProps> = ({ question, onChange, handler, previou
           disabled={question.disabled}
           readOnly={question.readonly}
         />
-        {question.questionOptions.showDate && (
+        {question.questionOptions.showDate === 'true' ? (
           <div style={{ marginTop: '5px' }}>
-            <InlineDate question={question} onChange={() => {}} handler={undefined} />
+            <InlineDate
+              question={question}
+              setObsDateTime={(value) => setObsDate(value)}
+              onChange={() => {}}
+              handler={ObsSubmissionHandler}
+            />
           </div>
+        ) : (
+          ''
         )}
       </div>
     )

--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -14,6 +14,7 @@ import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import InlineDate from '../inline-date/inline-date.component';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
+import { getQuestionValue } from '../../../utils/common-utils';
 
 import styles from './ui-select-extended.scss';
 
@@ -53,13 +54,7 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
   const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
-    question.value =
-      obsDate === undefined
-        ? handler?.handleFieldSubmission(question, value, encounterContext)
-        : handler?.handleFieldSubmission(question, value, {
-            ...encounterContext,
-            encounterDate: obsDate !== undefined ? obsDate : undefined,
-          });
+    question.value = getQuestionValue({ obsDate, question, value, encounterContext, handler });
   };
 
   useEffect(() => {
@@ -68,13 +63,7 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
       isProcessingSelection.current = true;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, setWarnings);
-      question.value =
-        obsDate === undefined
-          ? handler?.handleFieldSubmission(question, value, encounterContext)
-          : handler?.handleFieldSubmission(question, value, {
-              ...encounterContext,
-              encounterDate: obsDate !== undefined ? obsDate : undefined,
-            });
+      question.value = getQuestionValue({ obsDate, question, value, encounterContext, handler });
     }
   }, [previousValue]);
 
@@ -183,7 +172,6 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
             <InlineDate
               question={question}
               setObsDateTime={(value) => setObsDate(value)}
-              onChange={() => {}}
             />
           ) : null}
         </Layer>

--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -13,9 +13,9 @@ import { isInlineView } from '../../../utils/form-helper';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import InlineDate from '../inline-date/inline-date.component';
+import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 import styles from './ui-select-extended.scss';
-import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChange, previousValue }) => {
   const { t } = useTranslation();
@@ -29,6 +29,7 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
   const [config, setConfig] = useState({});
   const [savedSearchableItem, setSavedSearchableItem] = useState({});
   const { errors, setErrors, setWarnings } = useFieldValidationResults(question);
+  const [obsDate, setObsDate] = useState<Date>();
 
   const isInline = useMemo(() => {
     if (['view', 'embedded-view'].includes(encounterContext.sessionMode) || isTrue(question.readonly)) {
@@ -52,7 +53,13 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
   const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
-    handler?.handleFieldSubmission(question, value, encounterContext);
+    question.value =
+      obsDate === undefined
+        ? handler?.handleFieldSubmission(question, value, encounterContext)
+        : handler?.handleFieldSubmission(question, value, {
+            ...encounterContext,
+            encounterDate: obsDate !== undefined ? obsDate : undefined,
+          });
   };
 
   useEffect(() => {
@@ -61,7 +68,13 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
       isProcessingSelection.current = true;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, setWarnings);
-      handler?.handleFieldSubmission(question, value, encounterContext);
+      question.value =
+        obsDate === undefined
+          ? handler?.handleFieldSubmission(question, value, encounterContext)
+          : handler?.handleFieldSubmission(question, value, {
+              ...encounterContext,
+              encounterDate: obsDate !== undefined ? obsDate : undefined,
+            });
     }
   }, [previousValue]);
 
@@ -166,11 +179,13 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
               }
             }}
           />
-          {question.questionOptions.showDate && (
-            <div style={{ marginTop: '5px' }}>
-              <InlineDate question={question} onChange={() => {}} handler={undefined} />
-            </div>
-          )}
+          {question.questionOptions.showDate === 'true' ? (
+            <InlineDate
+              question={question}
+              setObsDateTime={(value) => setObsDate(value)}
+              onChange={() => {}}
+            />
+          ) : null}
         </Layer>
       </div>
     )

--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -15,7 +15,6 @@ import RequiredFieldLabel from '../../required-field-label/required-field-label.
 import InlineDate from '../inline-date/inline-date.component';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 import { getQuestionValue } from '../../../utils/common-utils';
-import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 import styles from './ui-select-extended.scss';
 

--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -12,6 +12,8 @@ import { isEmpty } from '../../../validators/form-validator';
 import { isInlineView } from '../../../utils/form-helper';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
+import InlineDate from '../inline-date/inline-date.component';
+
 import styles from './ui-select-extended.scss';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
@@ -164,6 +166,11 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
               }
             }}
           />
+          {question.questionOptions.showDate && (
+            <div style={{ marginTop: '5px' }}>
+              <InlineDate question={question} onChange={() => {}} handler={undefined} />
+            </div>
+          )}
         </Layer>
       </div>
     )

--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -15,6 +15,7 @@ import RequiredFieldLabel from '../../required-field-label/required-field-label.
 import InlineDate from '../inline-date/inline-date.component';
 import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 import { getQuestionValue } from '../../../utils/common-utils';
+import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 import styles from './ui-select-extended.scss';
 
@@ -54,7 +55,7 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
   const handleChange = (value) => {
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
-    question.value = getQuestionValue({ obsDate, question, value, encounterContext, handler });
+    getQuestionValue({ obsDate, question, value, encounterContext, handler });
   };
 
   useEffect(() => {
@@ -63,7 +64,7 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
       isProcessingSelection.current = true;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, setWarnings);
-      question.value = getQuestionValue({ obsDate, question, value, encounterContext, handler });
+      getQuestionValue({ obsDate, question, value, encounterContext, handler });
     }
   }, [previousValue]);
 

--- a/src/registry/registry.test.ts
+++ b/src/registry/registry.test.ts
@@ -2,6 +2,16 @@ import MultiSelect from '../components/inputs/multi-select/multi-select.componen
 import Number from '../components/inputs/number/number.component';
 import { getRegisteredControl } from './registry';
 
+const mockI18next = {
+  language: 'en', // Set the language to a valid value for your test
+};
+
+beforeAll(() => {
+  // Define window.i18next in the global scope
+  Object.defineProperty(window, 'i18next', {
+    value: mockI18next,
+  });
+});
 describe('registry', () => {
   it('should load the NumberField component with alias "numeric"', async () => {
     const result = await getRegisteredControl('numeric');

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,8 +158,6 @@ export interface FormFieldProps {
 export interface InlineDateProps {
   setObsDateTime: (value: Date) => void;
   question: FormField;
-  onChange: () => void;
-  handler: SubmissionHandler;
 }
 
 export interface FormSection {

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,6 +217,10 @@ export interface FormQuestionOptions {
   minLength?: string;
   showDate?: string;
   answers?: Array<QuestionAnswerOption>;
+  shownDateOptions?: {
+    validators?: Array<Record<string, any>>;
+  };
+  answers?: Array<Record<any, any>>;
   weeksList?: string;
   locationTag?: string;
   disallowDecimals?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,7 +140,6 @@ export interface previousValue {
   field: string;
   value: string | number | Date | boolean | previousValue[];
 }
-
 export interface FormFieldProps {
   question: FormField;
   onChange: (

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,13 @@ export interface FormFieldProps {
   previousValue?: previousValue;
 }
 
+export interface InlineDateProps {
+  setObsDateTime: (value: Date) => void;
+  question: FormField;
+  onChange: () => void;
+  handler: SubmissionHandler;
+}
+
 export interface FormSection {
   hide?: HideProps;
   label: string;
@@ -220,7 +227,6 @@ export interface FormQuestionOptions {
   shownDateOptions?: {
     validators?: Array<Record<string, any>>;
   };
-  answers?: Array<Record<any, any>>;
   weeksList?: string;
   locationTag?: string;
   disallowDecimals?: boolean;

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -65,3 +65,12 @@ export function gracefullySetSubmission(field: FormField, newValue: any, voidedV
 export function hasSubmission(field: FormField) {
   return !!field.meta.submission?.newValue || !!field.meta.submission?.voidedValue;
 }
+
+export function getQuestionValue({ obsDate, question, handler, value, encounterContext }) {
+  return  obsDate
+  ? handler?.handleFieldSubmission(question, value, {
+      ...encounterContext,
+      encounterDate: obsDate,
+    })
+  : handler?.handleFieldSubmission(question, value, encounterContext);
+}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR allows for retrospective entry of form fields by backdating the date

## Screenshots
- Disabled date if question value has not been entered
<img width="354" alt="Screenshot 2024-05-14 at 15 15 00" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/30952856/0a560c23-87d5-459d-80d2-1875869d052b">

- Recording
https://www.loom.com/share/d9fa21f0b98e444d86b4ccfa6a11b795
## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3052

## Other
<!-- Anything not covered above -->
