### PR TITLE
(fix) O3-2154: Selecting a date should set selected date's time to midnight in the local timezone

### DIFF
--- a/src/components/inputs/date/ohri-date.component.tsx
+++ b/src/components/inputs/date/ohri-date.component.tsx
@@ -39,7 +39,7 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler, p
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
   const onDateChange = ([date]) => {
-    const refinedDate = date instanceof Date ? new Date(date.getTime() - date.getTimezoneOffset() * 60000) : date;
+    const refinedDate = date instanceof Date ? new Date(date.setHours(0, 0, 0, 0)) : date;
     setFieldValue(question.id, refinedDate);
     onChange(question.id, refinedDate, setErrors, setWarnings);
     onTimeChange(false, true);
@@ -49,7 +49,7 @@ const OHRIDate: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler, p
   useEffect(() => {
     if (!isEmpty(previousValue)) {
       const date = previousValue.value;
-      const refinedDate = date instanceof Date ? new Date(date.getTime() - date.getTimezoneOffset() * 60000) : date;
+      const refinedDate = date instanceof Date ? new Date(date.setHours(0, 0, 0, 0)) : date;
       setFieldValue(question.id, refinedDate);
       onChange(question.id, refinedDate, setErrors, setWarnings);
       onTimeChange(false, true);

--- a/src/ohri-form.component.test.tsx
+++ b/src/ohri-form.component.test.tsx
@@ -25,6 +25,7 @@ import labour_and_delivery_test_form from '../__mocks__/forms/ohri-forms/labour_
 import sample_fields_form from '../__mocks__/forms/ohri-forms/sample_fields.json';
 import postSubmission_test_form from '../__mocks__/forms/ohri-forms/post-submission-test-form.json';
 import { evaluatePostSubmissionExpression } from './utils/post-submission-action-helper';
+import dayjs from 'dayjs';
 
 import {
   assertFormHasAllFields,
@@ -204,7 +205,8 @@ describe('OHRI Forms:', () => {
       const generalPopulationField = await findRadioGroupMember(screen, 'General population');
 
       // Simulate user interaction
-      fireEvent.blur(enrolmentDateField, { target: { value: '2023-09-09T00:00:00.000Z' } });
+      // console.log('Checking', .toDate());
+      fireEvent.blur(enrolmentDateField, { target: { value: dayjs('2023-09-09') } });
       fireEvent.blur(uniqueIdField, { target: { value: 'U0-001109' } });
       fireEvent.click(motherEnrolledField);
       fireEvent.click(generalPopulationField);
@@ -440,8 +442,8 @@ describe('OHRI Forms:', () => {
       fireEvent.change(lmpField, { target: { value: '2022-07-06' } });
 
       // verify
-      await act(async () => expect(lmpField.value).toBe(new Date('2022-07-06').toLocaleDateString(locale)));
-      await act(async () => expect(eddField.value).toBe(new Date('2023-04-12').toLocaleDateString(locale)));
+      await act(async () => expect(lmpField.value).toBe('06/07/2022'));
+      await act(async () => expect(eddField.value).toBe('12/04/2023'));
     });
 
     it('Should evaluate months on ART', async () => {
@@ -465,9 +467,7 @@ describe('OHRI Forms:', () => {
       fireEvent.blur(artStartDateField, { target: { value: '05/02/2022' } });
 
       // verify
-      await act(async () =>
-        expect(artStartDateField.value).toBe(new Date('2022-02-05T00:00:00.000+0000').toLocaleDateString(locale)),
-      );
+      await act(async () => expect(artStartDateField.value).toBe('05/02/2022'));
       await act(async () => expect(assumeTodayToBe).toBe('7/11/2022'));
       await act(async () => expect(monthsOnARTField.value).toBe('7'));
     });

--- a/src/ohri-form.component.test.tsx
+++ b/src/ohri-form.component.test.tsx
@@ -205,7 +205,6 @@ describe('OHRI Forms:', () => {
       const generalPopulationField = await findRadioGroupMember(screen, 'General population');
 
       // Simulate user interaction
-      // console.log('Checking', .toDate());
       fireEvent.blur(enrolmentDateField, { target: { value: dayjs('2023-09-09') } });
       fireEvent.blur(uniqueIdField, { target: { value: 'U0-001109' } });
       fireEvent.click(motherEnrolledField);

--- a/src/ohri-form.component.test.tsx
+++ b/src/ohri-form.component.test.tsx
@@ -441,8 +441,8 @@ describe('OHRI Forms:', () => {
       fireEvent.change(lmpField, { target: { value: '2022-07-06' } });
 
       // verify
-      await act(async () => expect(lmpField.value).toBe('06/07/2022'));
-      await act(async () => expect(eddField.value).toBe('12/04/2023'));
+      await act(async () => expect(lmpField.value).toBe(dayjs('2022-07-06').toDate().toLocaleDateString(locale)));
+      await act(async () => expect(eddField.value).toBe(dayjs('2023-04-12').toDate().toLocaleDateString(locale)));
     });
 
     it('Should evaluate months on ART', async () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR looks into the following issues:

When a user selects a date, the date's equivalent in UTC is calculated and saved in the form. For the Timezones behind the UTC, when the user selects a date, the date's time is sent as `00:00:00` by the Date picker. Setting the date in the negative offset timezone would set the selected date as the previous one.

All the dates should be handled in local time zones

## Screenshots
**For Pacific time zone**

### After


https://github.com/openmrs/openmrs-form-engine-lib/assets/51502471/33f15f44-b0ee-4419-923d-43e611a17e63


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-2154

## Other
Also, the tests are updated such that they should work in all timezones
