### PR TITLE
(test) Refactor tests for the Form component

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/openmrs/openmrs-form-engine-lib#readme",
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx --fix",
-    "verify": "turbo lint typescript test",
+    "verify": "turbo lint typescript test --concurrency=5",
     "test": "jest --config ./jest.config.js --passWithNoTests",
     "build": "webpack --mode production",
     "coverage": "yarn test --coverage",

--- a/src/components/loaders/loading.component.tsx
+++ b/src/components/loaders/loading.component.tsx
@@ -8,7 +8,12 @@ const LoadingIcon: React.FC = () => {
 
   return (
     <div className={styles['centerLoadingSVG']}>
-      <Loading description={t('activeLoadingIndicator', 'Active loading indicator')} withOverlay={false} small />
+      <Loading
+        description={t('activeLoadingIndicator', 'Active loading indicator')}
+        withOverlay={false}
+        role="progressbar"
+        small
+      />
     </div>
   );
 };

--- a/src/utils/test-utils.ts
+++ b/src/utils/test-utils.ts
@@ -1,3 +1,5 @@
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+
 export async function findNumberInput(screen, name: string): Promise<HTMLInputElement> {
   return await screen.findByRole('spinbutton', { name });
 }
@@ -51,4 +53,10 @@ export async function assertFormHasAllFields(screen, fields: Array<{ fieldName: 
     fields.map(({ fieldName, fieldType }) => fieldTypeToGetterMap[fieldType](screen, fieldName)),
   );
   await Promise.all(fieldsInDom.map((field) => expect(field).toBeInTheDocument()));
+}
+
+export function waitForLoadingToFinish() {
+  return waitForElementToBeRemoved(() => [...screen.queryAllByRole('progressbar')], {
+    timeout: 4000,
+  });
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR refactors tests for the Form component with the primary goal of reducing reliance on async behaviour and the use of asynchronous matchers. Consequently, the test suite _should_ be easier to read and reason about. In most cases, rendering the component, allowing some time for the asynchronous behaviour to occur, and then checking for the disappearance of the loading spinner should be enough to allow asynchronous operations to complete. 

In the few cases where the delay is insufficient and more time is required for async operations to complete, I've queued up the render using:

```tsx
await act(async () => {
  renderForm(null, obsGroupTestForm);
});
```

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
