### PR TITLE
(feat) O3-3099: Render labels instead of UUIDs for multiCheckbox field answers

### DIFF
--- a/src/components/inputs/multi-select/multi-select.component.tsx
+++ b/src/components/inputs/multi-select/multi-select.component.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { FilterableMultiSelect, Layer, UnorderedList } from '@carbon/react';
+import { FilterableMultiSelect, Layer, Tag } from '@carbon/react';
 import classNames from 'classnames';
 import { useField } from 'formik';
 import { useTranslation } from 'react-i18next';
@@ -59,7 +59,9 @@ export const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, hand
 
   const handleSelectItemsChange = ({ selectedItems }) => {
     setTouched(true);
-    const value = selectedItems.map((selectedItem) => selectedItem.concept);
+    const value = selectedItems.map((selectedItem) => {
+      return selectedItem.concept;
+    });
     setFieldValue(question.id, value);
     onChange(question.id, value, setErrors, setWarnings);
     question.value = handler?.handleFieldSubmission(question, value, encounterContext);
@@ -116,9 +118,13 @@ export const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, hand
         </div>
         <div className={styles.selectionDisplay}>
           {field.value?.length ? (
-            <UnorderedList className={styles.list}>
-              {handler?.getDisplayValue(question, field.value)?.map((displayValue) => displayValue + ', ')}
-            </UnorderedList>
+            <div className={styles.tagContainer}>
+              {handler?.getDisplayValue(question, field.value)?.map((displayValue, index) => (
+                <Tag key={index} type="cool-gray">
+                  {displayValue}
+                </Tag>
+              ))}
+            </div>
           ) : (
             <ValueEmpty />
           )}

--- a/src/components/inputs/multi-select/multi-select.scss
+++ b/src/components/inputs/multi-select/multi-select.scss
@@ -10,10 +10,10 @@
   font-weight: 600;
 }
 
-:global(.cds--list--unordered:not(.cds--list--nested)) {
-  margin-left: 0rem;
-}
-
 .selectionDisplay {
   margin-top: 0.125rem;
+}
+
+.tagContainer {
+  margin: 0.5rem 0;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The React Form Engine fails to accurately translate UUIDs into their corresponding selected answers for multi-select responses. While in multi-select responses with the Angular Form Engine, selected answers typically display in the box as expected, the React Form Engine presents the UUID rather than the selected answer.

## Screenshots

<img width="752" alt="Screenshot 2024-04-24 at 3 02 28 PM" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/46714226/2ce0335a-70c7-429c-8692-72b7176d5d2c">

## Related Issue
https://openmrs.atlassian.net/browse/O3-3099
## Other
<!-- Anything not covered above -->
