### PR TITLE
(fix) O3-3111: Fix stylings in the side navigation

### DIFF
--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -82,6 +82,7 @@
 }
 
 .sidebarSectionErrorActive {
+  @extend .sidebarSectionError;
   border-left: 0.5rem solid colors.$red-60;
   height: auto;
   font-weight: 600;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
When you try to submit a form with validation errors, the affected pages are highlighted for visibility. Previously the styling was  broken, this fix addresses that issue.

## Screenshots
![styling fix](https://github.com/openmrs/openmrs-form-engine-lib/assets/19221635/e43c22f1-afca-4127-9e1c-a645cfa8bde5)
![Screenshot from 2024-04-24 19-56-11](https://github.com/openmrs/openmrs-form-engine-lib/assets/19221635/f7621c98-b97f-4176-ba46-37464883582b)


## Related Issue
https://openmrs.atlassian.net/browse/O3-3111

## Other
