### PR TITLE
(feat) O3-3104: Improve scrolling top most invalid field in to view when the form is in an invalid state

### DIFF
--- a/src/utils/scroll-into-view.ts
+++ b/src/utils/scroll-into-view.ts
@@ -2,8 +2,8 @@ export function scrollIntoView(viewId: string, shouldFocus: boolean = false) {
   const currentElement = document.getElementById(viewId);
   currentElement?.scrollIntoView({
     behavior: 'smooth',
-    block: 'start',
-    inline: 'start',
+    block: 'center',
+    inline: 'center',
   });
 
   if (shouldFocus) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
 Improve scrolling top most invalid field in to view when the form is in an invalid state
 
## Screenshots
<!-- Required if you are making UI changes. -->
https://github.com/openmrs/openmrs-form-engine-lib/assets/53287480/70252dba-3fd8-4f4d-8039-f8eccefbce7b

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-3104](https://openmrs.atlassian.net/browse/O3-3104)

## Other
<!-- Anything not covered above -->
