### PR TITLE
(fix) fix tooltip alignment on obsGroup

### DIFF
--- a/src/components/group/obs-group.component.tsx
+++ b/src/components/group/obs-group.component.tsx
@@ -14,7 +14,7 @@ export interface ObsGroupProps extends FormFieldProps {
 
 export const ObsGroup: React.FC<ObsGroupProps> = ({ question, onChange, deleteControl }) => {
   const [groupMembersControlMap, setGroupMembersControlMap] = useState([]);
-  const { encounterContext, formFieldHandlers } = useContext(FormContext);
+  const { formFieldHandlers } = useContext(FormContext);
 
   useEffect(() => {
     if (question.questions) {
@@ -33,6 +33,9 @@ export const ObsGroup: React.FC<ObsGroupProps> = ({ question, onChange, deleteCo
     .map((groupMemberMapItem, index) => {
       const keyId = groupMemberMapItem.field.id + '-' + index;
       const { control, field } = groupMemberMapItem;
+
+      const rendering = field.questionOptions.rendering;
+
       if (control) {
         const questionFragment = React.createElement(control, {
           question: field,
@@ -45,16 +48,39 @@ export const ObsGroup: React.FC<ObsGroupProps> = ({ question, onChange, deleteCo
         return (
           <div className={classNames(styles.flexColumn, styles.obsGroupColumn)} key={keyId}>
             <div className={styles.parentResizer}>
-              {questionFragment}
               <div
                 className={classNames({
-                  [styles.tooltipWithUnspecified]: isUnspecifiedSupported(field),
-                  [styles.tooltip]: !isUnspecifiedSupported(field),
+                  [styles.questionInfoDefault]: field.questionInfo && rendering === 'radio',
+                  [styles.questionInfoCentralized]: field.questionInfo && rendering !== 'radio',
                 })}>
+                <div
+                  className={classNames({
+                    [styles.flexBasisOn]: [
+                      'ui-select-extended',
+                      'content-switcher',
+                      'select',
+                      'textarea',
+                      'text',
+                      'checkbox',
+                    ].includes(rendering),
+                  })}>
+                  {questionFragment}
+                </div>
+                {field.questionInfo && (
+                  <div className={styles.questionInfoControl}>
+                    <Tooltip field={field} />
+                  </div>
+                )}
+              </div>
+              <div
+              // className={classNames({
+              //   [styles.tooltipWithUnspecified]: isUnspecifiedSupported(field),
+              //   [styles.tooltip]: !isUnspecifiedSupported(field),
+              // })}
+              >
                 {isUnspecifiedSupported(field) && (
                   <UnspecifiedField question={field} onChange={onChange} handler={formFieldHandlers[field.type]} />
                 )}
-                {field.questionInfo && <Tooltip field={field} />}
               </div>
             </div>
           </div>

--- a/src/components/group/obs-group.component.tsx
+++ b/src/components/group/obs-group.component.tsx
@@ -72,12 +72,7 @@ export const ObsGroup: React.FC<ObsGroupProps> = ({ question, onChange, deleteCo
                   </div>
                 )}
               </div>
-              <div
-              // className={classNames({
-              //   [styles.tooltipWithUnspecified]: isUnspecifiedSupported(field),
-              //   [styles.tooltip]: !isUnspecifiedSupported(field),
-              // })}
-              >
+              <div>
                 {isUnspecifiedSupported(field) && (
                   <UnspecifiedField question={field} onChange={onChange} handler={formFieldHandlers[field.type]} />
                 )}

--- a/src/components/section/form-section.scss
+++ b/src/components/section/form-section.scss
@@ -34,7 +34,7 @@
   display: flex;
   align-items: center !important;
 
-  > .questionInfoControl {
+  >.questionInfoControl {
     padding-top: 1.5rem;
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
There had been an issue reported where the general alignment of the tooltip within the form fields does not cascade to the obs group fields: (see image below)

![Screenshot 2024-04-26 at 01 14 09](https://github.com/openmrs/openmrs-form-engine-lib/assets/51090527/af26af81-9937-4b48-a910-467de00694cb)

This PR resolves this.
## Screenshots
<!-- Required if you are making UI changes. -->
<img width="774" alt="Screenshot 2024-04-26 at 10 48 18" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/51090527/5d578d62-dd1a-45d3-9f9a-7b6778ef6c40">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
