### PR TITLE
(chore) Switch @carbon/react to peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@carbon/react": "^1.37.0",
     "ace-builds": "^1.4.12",
     "classnames": "^2.5.1",
     "dayjs": "1.x",
@@ -40,6 +39,7 @@
     "yup": "^0.29.1"
   },
   "peerDependencies": {
+    "@carbon/react": "1.x",
     "@openmrs/esm-framework": "5.x",
     "@openmrs/esm-patient-common-lib": "7.x",
     "dayjs": "1.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3254,6 +3254,7 @@ __metadata:
     webpack-dev-server: "npm:^4.13.1"
     yup: "npm:^0.29.1"
   peerDependencies:
+    "@carbon/react": 1.x
     "@openmrs/esm-framework": 5.x
     "@openmrs/esm-patient-common-lib": 7.x
     dayjs: 1.x


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
`@carbon/react` had been switched to a dependency in a previous PR to reduce the bundle size but the catch is consuming esms might have varying versions which end up conflicting with it and causing UI issues like unintended scroll bars. 

This also raises an issue with `yarn link` that stalls the development process. 

**THIS MIGHT BE REVISITED LATER ON**


## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
