### PR TITLE
(fix) 03-3126 : Aligning field width within an an obs-group

### DIFF
--- a/src/components/group/obs-group.component.tsx
+++ b/src/components/group/obs-group.component.tsx
@@ -33,7 +33,7 @@ export const ObsGroup: React.FC<FormFieldProps> = ({ question, onChange }) => {
       if (FieldComponent) {
         return (
           <div className={classNames(styles.flexColumn)} key={keyId}>
-            <div className={styles.obsGroupContainer}>
+            <div className={styles.parentResizer}>
               <div
                 className={classNames({
                   [styles.questionInfoDefault]: field.questionInfo && rendering === 'radio',

--- a/src/components/group/obs-group.component.tsx
+++ b/src/components/group/obs-group.component.tsx
@@ -32,8 +32,8 @@ export const ObsGroup: React.FC<FormFieldProps> = ({ question, onChange }) => {
       const rendering = field.questionOptions.rendering;
       if (FieldComponent) {
         return (
-          <div className={classNames(styles.flexColumn, styles.obsGroupColumn)} key={keyId}>
-            <div className={styles.parentResizer}>
+          <div className={classNames(styles.flexColumn)} key={keyId}>
+            <div className={styles.obsGroupContainer}>
               <div
                 className={classNames({
                   [styles.questionInfoDefault]: field.questionInfo && rendering === 'radio',

--- a/src/components/section/form-section.scss
+++ b/src/components/section/form-section.scss
@@ -5,6 +5,10 @@
   margin-bottom: 1.5rem;
 }
 
+.obsGroupContainer {
+  width: 93%;
+}
+
 .unspecifiedContainer {
   display: flex;
   justify-content: space-between;
@@ -34,7 +38,7 @@
   display: flex;
   align-items: center !important;
 
-  >.questionInfoControl {
+  > .questionInfoControl {
     padding-top: 1.5rem;
   }
 }

--- a/src/components/section/form-section.scss
+++ b/src/components/section/form-section.scss
@@ -5,10 +5,6 @@
   margin-bottom: 1.5rem;
 }
 
-.obsGroupContainer {
-  width: 93%;
-}
-
 .unspecifiedContainer {
   display: flex;
   justify-content: space-between;
@@ -31,7 +27,7 @@
 
 .sectionContainer {
   margin-top: 1rem;
-  width: 90%;
+  width: 100%;
 }
 
 .questionInfoCentralized {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

https://openmrs.atlassian.net/browse/O3-3126

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<img width="1354" alt="Screenshot 2024-04-26 at 1 24 20 PM" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/46714226/eb2f5dac-1c33-4ff8-8cd3-13129039e87b">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
