### PR TITLE
(feat) Fetch all concept references of the the form with SWR Infinite

### DIFF
--- a/src/hooks/useConcepts.tsx
+++ b/src/hooks/useConcepts.tsx
@@ -1,14 +1,50 @@
-import useSWRImmutable from 'swr/immutable';
-import { openmrsFetch, OpenmrsResource, restBaseUrl } from '@openmrs/esm-framework';
+import useSWRInfinite from 'swr/infinite';
+import { FetchResponse, openmrsFetch, OpenmrsResource, restBaseUrl } from '@openmrs/esm-framework';
+import { useMemo } from 'react';
 
 const conceptRepresentation =
   'custom:(uuid,display,conceptClass:(uuid,display),answers:(uuid,display),conceptMappings:(conceptReferenceTerm:(conceptSource:(name),code)))';
 
-export function useConcepts(references: Set<string>) {
-  // TODO: handle paging (ie when number of concepts greater than default limit per page)
-  const { data, error, isLoading } = useSWRImmutable<{ data: { results: Array<OpenmrsResource> } }, Error>(
-    `${restBaseUrl}/concept?references=${Array.from(references).join(',')}&v=${conceptRepresentation}`,
+const chunkSize = 100;
+
+export function useConcepts(references: Set<string>): {
+  concepts: Array<OpenmrsResource> | undefined;
+  isLoading: boolean;
+  error: Error | undefined;
+} {
+  const totalCount = references.size;
+  const totalPages = Math.ceil(totalCount / chunkSize);
+
+  const getUrl = (index) => {
+    if (index >= totalPages) {
+      return null;
+    }
+
+    const start = index * chunkSize;
+    const end = start + chunkSize;
+    const chunk = Array.from(references).slice(start, end);
+    return `${restBaseUrl}/concept?references=${chunk.join(',')}&v=${conceptRepresentation}&limit=${chunkSize}`;
+  };
+
+  const { data, error, isLoading } = useSWRInfinite<FetchResponse<{ results: Array<OpenmrsResource> }>, Error>(
+    getUrl,
     openmrsFetch,
+    {
+      initialSize: totalPages,
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    },
   );
-  return { concepts: data?.data.results, error, isLoading };
+
+  const results = useMemo(
+    () => ({
+      concepts: data ? [].concat(data?.map((res) => res?.data?.results).flat()) : undefined,
+      error,
+      isLoading,
+    }),
+    [data, error, isLoading],
+  );
+
+  return results;
 }

--- a/src/utils/form-helper.ts
+++ b/src/utils/form-helper.ts
@@ -140,7 +140,7 @@ export function findConceptByReference(reference: string, concepts) {
   } else {
     // handle uuid
     return concepts?.find((concept) => {
-      return concept.uuid === reference;
+      return concept?.uuid === reference;
     });
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
Currently, out of all concept references, only the top 50 references are fetched. With `useSWRInfinite` we can fetch all the concept references for the form in batches.

## Screenshots
## Before

## After


## Related Issue
None

## Other
<!-- Anything not covered above -->
