### PR TITLE
(refactor) Use one component export syntax for consistency

### DIFF
--- a/src/components/encounter/encounter-form.component.tsx
+++ b/src/components/encounter/encounter-form.component.tsx
@@ -61,7 +61,7 @@ interface EncounterFormProps {
   setIsSubmitting?: Dispatch<SetStateAction<boolean>>;
 }
 
-export const EncounterForm: React.FC<EncounterFormProps> = ({
+const EncounterForm: React.FC<EncounterFormProps> = ({
   formJson,
   patient,
   formSessionDate,
@@ -878,3 +878,5 @@ export const EncounterForm: React.FC<EncounterFormProps> = ({
     </FormContext.Provider>
   );
 };
+
+export default EncounterForm;

--- a/src/components/group/obs-group.component.tsx
+++ b/src/components/group/obs-group.component.tsx
@@ -4,15 +4,15 @@ import { useField } from 'formik';
 import { FormContext } from '../../form-context';
 import { type FormFieldProps } from '../../types';
 import { getFieldControlWithFallback, isUnspecifiedSupported } from '../section/helpers';
-import { UnspecifiedField } from '../inputs/unspecified/unspecified.component';
-import { Tooltip } from '../inputs/tooltip/tooltip.component';
+import Tooltip from '../inputs/tooltip/tooltip.component';
+import UnspecifiedField from '../inputs/unspecified/unspecified.component';
 import styles from '../section/form-section.scss';
 
 export interface ObsGroupProps extends FormFieldProps {
   deleteControl?: any;
 }
 
-export const ObsGroup: React.FC<ObsGroupProps> = ({ question, onChange, deleteControl }) => {
+const ObsGroup: React.FC<ObsGroupProps> = ({ question, onChange, deleteControl }) => {
   const [groupMembersControlMap, setGroupMembersControlMap] = useState([]);
   const { formFieldHandlers } = useContext(FormContext);
 
@@ -89,3 +89,5 @@ export const ObsGroup: React.FC<ObsGroupProps> = ({ question, onChange, deleteCo
 
   return <div className={styles.flexRow}>{groupContent}</div>;
 };
+
+export default ObsGroup;

--- a/src/components/inputs/content-switcher/content-switcher.component.tsx
+++ b/src/components/inputs/content-switcher/content-switcher.component.tsx
@@ -1,17 +1,17 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import { FormGroup, ContentSwitcher as CdsContentSwitcher, Switch } from '@carbon/react';
 import { useField } from 'formik';
 import { isInlineView } from '../../../utils/form-helper';
 import { isEmpty } from '../../../validators/form-validator';
 import { isTrue } from '../../../utils/boolean-utils';
-import { FieldValueView } from '../../value/view/field-value-view.component';
 import { FormContext } from '../../../form-context';
 import { type FormFieldProps } from '../../../types';
+import FieldValueView from '../../value/view/field-value-view.component';
 import styles from './content-switcher.scss';
-import { useTranslation } from 'react-i18next';
 
-export const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
+const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
   const { t } = useTranslation();
   const [field, meta] = useField(question.id);
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
@@ -87,3 +87,5 @@ export const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, 
     )
   );
 };
+
+export default ContentSwitcher;

--- a/src/components/inputs/content-switcher/content-switcher.test.tsx
+++ b/src/components/inputs/content-switcher/content-switcher.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent, screen, cleanup, act, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
-import { ContentSwitcher } from './content-switcher.component';
+import ContentSwitcher from './content-switcher.component';
 import { type EncounterContext, FormContext } from '../../../form-context';
 import { type FormField } from '../../../types';
 import { ObsSubmissionHandler } from '../../../submission-handlers/base-handlers';

--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -8,9 +8,9 @@ import { formatDate } from '@openmrs/esm-framework';
 import { isTrue } from '../../../utils/boolean-utils';
 import { type FormFieldProps } from '../../../types';
 import { isInlineView } from '../../../utils/form-helper';
-import { FieldValueView } from '../../value/view/field-value-view.component';
 import { fieldRequiredErrCode, isEmpty } from '../../../validators/form-validator';
 import { FormContext } from '../../../form-context';
+import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import styles from './date.scss';
 

--- a/src/components/inputs/multi-select/multi-select.component.tsx
+++ b/src/components/inputs/multi-select/multi-select.component.tsx
@@ -3,17 +3,17 @@ import { FilterableMultiSelect, Layer, Tag } from '@carbon/react';
 import classNames from 'classnames';
 import { useField } from 'formik';
 import { useTranslation } from 'react-i18next';
-import { FieldValueView } from '../../value/view/field-value-view.component';
 import { FormContext } from '../../../form-context';
 import { type FormFieldProps } from '../../../types';
 import { ValueEmpty } from '../../value/value.component';
 import { fieldRequiredErrCode, isEmpty } from '../../../validators/form-validator';
 import { isInlineView } from '../../../utils/form-helper';
 import { isTrue } from '../../../utils/boolean-utils';
+import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import styles from './multi-select.scss';
 
-export const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
+const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
   const { t } = useTranslation();
   const [field, meta] = useField(question.id);
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
@@ -138,3 +138,5 @@ export const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, hand
     )
   );
 };
+
+export default MultiSelect;

--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -5,7 +5,7 @@ import { useField } from 'formik';
 import { isTrue } from '../../../utils/boolean-utils';
 import { fieldRequiredErrCode, isEmpty } from '../../../validators/form-validator';
 import { isInlineView } from '../../../utils/form-helper';
-import { FieldValueView } from '../../value/view/field-value-view.component';
+import FieldValueView from '../../value/view/field-value-view.component';
 import { type FormFieldProps } from '../../../types';
 import { FormContext } from '../../../form-context';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';

--- a/src/components/inputs/radio/radio.component.tsx
+++ b/src/components/inputs/radio/radio.component.tsx
@@ -8,7 +8,7 @@ import { FormContext } from '../../../form-context';
 import { isTrue } from '../../../utils/boolean-utils';
 import { isInlineView } from '../../../utils/form-helper';
 import { fieldRequiredErrCode, isEmpty } from '../../../validators/form-validator';
-import { FieldValueView } from '../../value/view/field-value-view.component';
+import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import styles from './radio.scss';
 

--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -6,9 +6,9 @@ import { useField } from 'formik';
 import { fieldRequiredErrCode, isEmpty } from '../../../validators/form-validator';
 import { isInlineView } from '../../../utils/form-helper';
 import { isTrue } from '../../../utils/boolean-utils';
-import { FieldValueView } from '../../value/view/field-value-view.component';
 import { FormContext } from '../../../form-context';
 import { type FormFieldProps } from '../../../types';
+import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import styles from './dropdown.scss';
 

--- a/src/components/inputs/text-area/text-area.component.tsx
+++ b/src/components/inputs/text-area/text-area.component.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
+import { useTranslation } from 'react-i18next';
 import { Layer, TextArea as TextAreaInput } from '@carbon/react';
 import { useField } from 'formik';
 import { fieldRequiredErrCode, isEmpty } from '../../../validators/form-validator';
 import { isInlineView } from '../../../utils/form-helper';
 import { isTrue } from '../../../utils/boolean-utils';
-import { FieldValueView } from '../../value/view/field-value-view.component';
 import { FormContext } from '../../../form-context';
 import { type FormFieldProps } from '../../../types';
+import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import styles from './text-area.scss';
-import { useTranslation } from 'react-i18next';
 
 const TextArea: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue: previousValueProp }) => {
   const { t } = useTranslation();

--- a/src/components/inputs/text/text.component.tsx
+++ b/src/components/inputs/text/text.component.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import isEmpty from 'lodash-es/isEmpty';
+import { useTranslation } from 'react-i18next';
 import { Layer, TextInput } from '@carbon/react';
 import { useField } from 'formik';
 import { type FormFieldProps } from '../../../types';
@@ -8,10 +9,9 @@ import { FormContext } from '../../../form-context';
 import { fieldRequiredErrCode } from '../../../validators/form-validator';
 import { isTrue } from '../../../utils/boolean-utils';
 import { isInlineView } from '../../../utils/form-helper';
-import { FieldValueView } from '../../value/view/field-value-view.component';
+import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import styles from './text.scss';
-import { useTranslation } from 'react-i18next';
 
 const TextField: React.FC<FormFieldProps> = ({ question, onChange, handler, previousValue }) => {
   const { t } = useTranslation();

--- a/src/components/inputs/toggle/toggle.component.tsx
+++ b/src/components/inputs/toggle/toggle.component.tsx
@@ -5,7 +5,7 @@ import { useField } from 'formik';
 import { FormContext } from '../../../form-context';
 import { isTrue } from '../../../utils/boolean-utils';
 import { isInlineView } from '../../../utils/form-helper';
-import { FieldValueView } from '../../value/view/field-value-view.component';
+import FieldValueView from '../../value/view/field-value-view.component';
 import { isEmpty } from '../../../validators/form-validator';
 import { booleanConceptToBoolean } from '../../../utils/common-expression-helpers';
 import styles from './toggle.scss';

--- a/src/components/inputs/tooltip/tooltip.component.tsx
+++ b/src/components/inputs/tooltip/tooltip.component.tsx
@@ -9,7 +9,7 @@ interface TooltipProps {
   field: FormField;
 }
 
-export const Tooltip: React.FC<TooltipProps> = ({ field }) => {
+const Tooltip: React.FC<TooltipProps> = ({ field }) => {
   const { t } = useTranslation();
   return (
     <CarbonTooltip align="top" label={t(field.questionInfo)} description={t(field.questionInfo)}>
@@ -19,3 +19,5 @@ export const Tooltip: React.FC<TooltipProps> = ({ field }) => {
     </CarbonTooltip>
   );
 };
+
+export default Tooltip;

--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import debounce from 'lodash-es/debounce';
 import { ComboBox, InlineLoading, Layer } from '@carbon/react';
 import { useField } from 'formik';
-import { FieldValueView } from '../../value/view/field-value-view.component';
 import { isTrue } from '../../../utils/boolean-utils';
 import { useTranslation } from 'react-i18next';
 import { getRegisteredDataSource } from '../../../registry/registry';
@@ -11,6 +10,7 @@ import { getControlTemplate } from '../../../registry/inbuilt-components/control
 import { FormContext } from '../../../form-context';
 import { type FormFieldProps } from '../../../types';
 import { fieldRequiredErrCode, isEmpty } from '../../../validators/form-validator';
+import FieldValueView from '../../value/view/field-value-view.component';
 import { isInlineView } from '../../../utils/form-helper';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import styles from './ui-select-extended.scss';

--- a/src/components/inputs/unspecified/unspecified.component.tsx
+++ b/src/components/inputs/unspecified/unspecified.component.tsx
@@ -8,7 +8,7 @@ import { type FormFieldProps } from '../../../types';
 import { isTrue } from '../../../utils/boolean-utils';
 import styles from './unspecified.scss';
 
-export const UnspecifiedField: React.FC<FormFieldProps> = ({ question, onChange, handler }) => {
+const UnspecifiedField: React.FC<FormFieldProps> = ({ question, onChange, handler }) => {
   const { t } = useTranslation();
   const [field, meta] = useField(`${question.id}-unspecified`);
   const { setFieldValue, encounterContext, fields } = React.useContext(FormContext);
@@ -82,3 +82,5 @@ export const UnspecifiedField: React.FC<FormFieldProps> = ({ question, onChange,
     )
   );
 };
+
+export default UnspecifiedField;

--- a/src/components/inputs/unspecified/unspecified.test.tsx
+++ b/src/components/inputs/unspecified/unspecified.test.tsx
@@ -3,9 +3,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { Formik } from 'formik';
 import { type FormField, type EncounterContext, FormContext } from '../../..';
 import { ObsSubmissionHandler } from '../../../submission-handlers/base-handlers';
-import { UnspecifiedField } from './unspecified.component';
 import { findTextOrDateInput } from '../../../utils/test-utils';
 import DateField from '../date/date.component';
+import UnspecifiedField from './unspecified.component';
 
 const question: FormField = {
   label: 'Visit Date',

--- a/src/components/label/label.component.tsx
+++ b/src/components/label/label.component.tsx
@@ -7,7 +7,7 @@ type LabelProps = {
   tooltipText?: string;
 };
 
-export const LabelField: React.FC<LabelProps> = ({ value, tooltipText }) => {
+const LabelField: React.FC<LabelProps> = ({ value, tooltipText }) => {
   return (
     <div className={styles.label}>
       <DefinitionTooltip direction="bottom" tabIndex={0} tooltipText={tooltipText}>
@@ -16,3 +16,5 @@ export const LabelField: React.FC<LabelProps> = ({ value, tooltipText }) => {
     </div>
   );
 };
+
+export default LabelField;

--- a/src/components/patient-banner/patient-banner.component.tsx
+++ b/src/components/patient-banner/patient-banner.component.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { ExtensionSlot } from '@openmrs/esm-framework';
 import styles from './patient-banner.scss';
 
-export const PatientBanner: React.FC<{ patient: any; hideActionsOverflow?: any }> = ({
-  patient,
-  hideActionsOverflow,
-}) => {
+const PatientBanner: React.FC<{ patient: any; hideActionsOverflow?: any }> = ({ patient, hideActionsOverflow }) => {
   return (
     <div className={styles.patientBannerContainer}>
       <ExtensionSlot
@@ -19,3 +16,5 @@ export const PatientBanner: React.FC<{ patient: any; hideActionsOverflow?: any }
     </div>
   );
 };
+
+export default PatientBanner;

--- a/src/components/previous-value-review/previous-value-review.component.tsx
+++ b/src/components/previous-value-review/previous-value-review.component.tsx
@@ -11,7 +11,7 @@ type Props = {
   hideHeader?: boolean;
 };
 
-export const PreviousValueReview: React.FC<Props> = ({ previousValue, displayText, setValue, field, hideHeader }) => {
+const PreviousValueReview: React.FC<Props> = ({ previousValue, displayText, setValue, field, hideHeader }) => {
   const { t } = useTranslation();
 
   return (
@@ -40,3 +40,5 @@ export const PreviousValueReview: React.FC<Props> = ({ previousValue, displayTex
     </div>
   );
 };
+
+export default PreviousValueReview;

--- a/src/components/repeat/repeat.component.tsx
+++ b/src/components/repeat/repeat.component.tsx
@@ -5,7 +5,7 @@ import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { type FormField, type FormFieldProps } from '../../types';
 import { evaluateAsyncExpression, evaluateExpression } from '../../utils/expression-runner';
-import { ObsGroup } from '../group/obs-group.component';
+import ObsGroup from '../group/obs-group.component';
 import { isEmpty } from '../../validators/form-validator';
 import styles from './repeat.scss';
 import { cloneObsGroup } from './helpers';

--- a/src/components/section/form-section.component.tsx
+++ b/src/components/section/form-section.component.tsx
@@ -8,10 +8,10 @@ import { ToastNotification } from '@carbon/react';
 import { formatPreviousValueDisplayText, getFieldControlWithFallback, isUnspecifiedSupported } from './helpers';
 import { getRegisteredFieldSubmissionHandler } from '../../registry/registry';
 import { isTrue } from '../../utils/boolean-utils';
-import { UnspecifiedField } from '../inputs/unspecified/unspecified.component';
 import { FormContext } from '../../form-context';
-import { PreviousValueReview } from '../previous-value-review/previous-value-review.component';
-import { Tooltip } from '../inputs/tooltip/tooltip.component';
+import PreviousValueReview from '../previous-value-review/previous-value-review.component';
+import Tooltip from '../inputs/tooltip/tooltip.component';
+import UnspecifiedField from '../inputs/unspecified/unspecified.component';
 import styles from './form-section.scss';
 
 interface FieldComponentMap {

--- a/src/components/value/view/field-value-view.component.tsx
+++ b/src/components/value/view/field-value-view.component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LabelField } from '../../label/label.component';
+import LabelField from '../../label/label.component';
 import { ValueDisplay, ValueEmpty } from '../value.component';
 import styles from './field-value-view.scss';
 
@@ -9,7 +9,8 @@ interface FieldValueViewProps {
   value: any;
   conceptName: string;
 }
-export const FieldValueView: React.FC<FieldValueViewProps> = ({ label, conceptName, value, isInline }) => (
+
+const FieldValueView: React.FC<FieldValueViewProps> = ({ label, conceptName, value, isInline }) => (
   <>
     {isInline ? (
       <div className={styles.inlineFlexRow}>
@@ -28,3 +29,5 @@ export const FieldValueView: React.FC<FieldValueViewProps> = ({ label, conceptNa
     )}
   </>
 );
+
+export default FieldValueView;

--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -10,17 +10,17 @@ import LoadingIcon from './components/loaders/loading.component';
 import Sidebar from './components/sidebar/sidebar.component';
 import { init, teardown } from './lifecycle';
 import type { FormSchema, SessionMode, FormPage as FormPageProps } from './types';
-import { PatientBanner } from './components/patient-banner/patient-banner.component';
 import { extractErrorMessagesFromResponse, reportError } from './utils/error-utils';
 import { useFormJson } from './hooks/useFormJson';
 import { usePostSubmissionAction } from './hooks/usePostSubmissionAction';
 import { useWorkspaceLayout } from './hooks/useWorkspaceLayout';
 import { usePatientData } from './hooks/usePatientData';
 import { evaluatePostSubmissionExpression } from './utils/post-submission-action-helper';
+import { moduleName } from './globals';
+import EncounterForm from './components/encounter/encounter-form.component';
+import PatientBanner from './components/patient-banner/patient-banner.component';
 import MarkdownWrapper from './components/inputs/markdown/markdown-wrapper.component';
 import styles from './form-engine.scss';
-import { EncounterForm } from './components/encounter/encounter-form.component';
-import { moduleName } from './globals';
 
 interface FormProps {
   patientUUID: string;

--- a/src/registry/inbuilt-components/inbuiltControls.ts
+++ b/src/registry/inbuilt-components/inbuiltControls.ts
@@ -3,22 +3,22 @@ import { type RegistryItem } from '../registry';
 import { controlTemplates } from './control-templates';
 import { templateToComponentMap } from './template-component-map';
 import { type FormFieldProps } from '../../types';
+import ContentSwitcher from '../../components/inputs/content-switcher/content-switcher.component';
 import DateField from '../../components/inputs/date/date.component';
-import Radio from '../../components/inputs/radio/radio.component';
-import NumberField from '../../components/inputs/number/number.component';
-import TextField from '../../components/inputs/text/text.component';
-import { MultiSelect } from '../../components/inputs/multi-select/multi-select.component';
-import { ContentSwitcher } from '../../components/inputs/content-switcher/content-switcher.component';
-import TextArea from '../../components/inputs/text-area/text-area.component';
 import Dropdown from '../../components/inputs/select/dropdown.component';
-import Toggle from '../../components/inputs/toggle/toggle.component';
-import { ObsGroup } from '../../components/group/obs-group.component';
-import Repeat from '../../components/repeat/repeat.component';
-import Markdown from '../../components/inputs/markdown/markdown.component';
-import FixedValue from '../../components/inputs/fixed-value/fixed-value.component';
 import ExtensionParcel from '../../components/extension/extension-parcel.component';
-import WorkspaceLauncher from '../../components/inputs/workspace-launcher/workspace-launcher.component';
+import FixedValue from '../../components/inputs/fixed-value/fixed-value.component';
+import Markdown from '../../components/inputs/markdown/markdown.component';
+import MultiSelect from '../../components/inputs/multi-select/multi-select.component';
+import NumberField from '../../components/inputs/number/number.component';
+import ObsGroup from '../../components/group/obs-group.component';
+import Radio from '../../components/inputs/radio/radio.component';
+import Repeat from '../../components/repeat/repeat.component';
+import TextArea from '../../components/inputs/text-area/text-area.component';
+import TextField from '../../components/inputs/text/text.component';
+import Toggle from '../../components/inputs/toggle/toggle.component';
 import UiSelectExtended from '../../components/inputs/ui-select-extended/ui-select-extended.component';
+import WorkspaceLauncher from '../../components/inputs/workspace-launcher/workspace-launcher.component';
 
 /**
  * @internal

--- a/src/registry/registry.test.ts
+++ b/src/registry/registry.test.ts
@@ -1,4 +1,4 @@
-import { MultiSelect } from '../components/inputs/multi-select/multi-select.component';
+import MultiSelect from '../components/inputs/multi-select/multi-select.component';
 import Number from '../components/inputs/number/number.component';
 import { getRegisteredControl } from './registry';
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

We currently use a mix of named and default exports for components. This PR switches to using default exports for components with a single export, similar to what we do in other repositories. This makes things more consistent.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
