### PR TITLE
(fix) Update registry to use `name` as the canonical identifier for derived rendering types

### DIFF
--- a/src/registry/inbuilt-components/inbuiltControls.ts
+++ b/src/registry/inbuilt-components/inbuiltControls.ts
@@ -100,8 +100,7 @@ export const inbuiltControls: Array<RegistryItem<React.ComponentType<FormFieldPr
     component: WorkspaceLauncher,
   },
   ...controlTemplates.map((template) => ({
-    name: `${template.name}Control`,
+    name: template.name,
     component: templateToComponentMap.find((component) => component.name === template.name).baseControlComponent,
-    type: template.name,
   })),
 ];


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This fixes the issue related to rendering types: `encounter-provider`, `encounter-location`, `problem` and `drug` reported not working.

## Screenshots
<!-- Required if you are making UI changes. -->


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
