### PR TITLE
field-validation:Enabling default field validation for multi-checkbox field values 

### DIFF
--- a/src/validators/default-value-validator.ts
+++ b/src/validators/default-value-validator.ts
@@ -5,7 +5,11 @@ import { codedTypes } from '../constants';
 export const DefaultFieldValueValidator: FormFieldValidator = {
   validate: (field: FormField, value: any) => {
     if (codedTypes.includes(field.questionOptions.rendering)) {
-      if (!value.some((val) => field.questionOptions.answers?.find((answer) => answer.concept === val))) {
+      const valuesToCheck = Array.isArray(value) ? value : [value];
+      // check whether value exists in answers
+      if (
+        !valuesToCheck.some((val: string) => field.questionOptions.answers?.find((answer) => answer.concept === val))
+      ) {
         return [
           { resultType: 'error', errCode: 'invalid.defaultValue', message: 'Value not found in coded answers list' },
         ];

--- a/src/validators/default-value-validator.ts
+++ b/src/validators/default-value-validator.ts
@@ -8,7 +8,7 @@ export const DefaultFieldValueValidator: FormFieldValidator = {
       const valuesToCheck = Array.isArray(value) ? value : [value];
       // check whether value exists in answers
       if (
-        !valuesToCheck.some((val: string) => field.questionOptions.answers?.find((answer) => answer.concept === val))
+        !valuesToCheck.every((val: string) => field.questionOptions.answers?.find((answer) => answer.concept === val))
       ) {
         return [
           { resultType: 'error', errCode: 'invalid.defaultValue', message: 'Value not found in coded answers list' },

--- a/src/validators/default-value-validator.ts
+++ b/src/validators/default-value-validator.ts
@@ -6,7 +6,15 @@ export const DefaultFieldValueValidator: FormFieldValidator = {
   validate: (field: FormField, value: any) => {
     if (codedTypes.includes(field.questionOptions.rendering)) {
       // check whether value exists in answers
-      if (!field.questionOptions.answers?.find((answer) => answer.concept == value)) {
+      // if (!field.questionOptions.answers?.find((answer) => answer.concept == value)) {
+      //   // eslint-disable-next-line no-console
+      //   console.log(value);
+
+      //   return [
+      //     { resultType: 'error', errCode: 'invalid.defaultValue', message: 'Value not found in coded answers list' },
+      //   ];
+      // }
+      if (!value.some((val) => field.questionOptions.answers?.find((answer) => answer.concept === val))) {
         return [
           { resultType: 'error', errCode: 'invalid.defaultValue', message: 'Value not found in coded answers list' },
         ];

--- a/src/validators/default-value-validator.ts
+++ b/src/validators/default-value-validator.ts
@@ -5,10 +5,10 @@ import { codedTypes } from '../constants';
 export const DefaultFieldValueValidator: FormFieldValidator = {
   validate: (field: FormField, value: any) => {
     if (codedTypes.includes(field.questionOptions.rendering)) {
-      const valuesToCheck = Array.isArray(value) ? value : [value];
+      const valuesArray = Array.isArray(value) ? value : [value];
       // check whether value exists in answers
       if (
-        !valuesToCheck.every((val: string) => field.questionOptions.answers?.find((answer) => answer.concept === val))
+        !valuesArray.every((val: string) => field.questionOptions.answers?.find((answer) => answer.concept === val))
       ) {
         return [
           { resultType: 'error', errCode: 'invalid.defaultValue', message: 'Value not found in coded answers list' },

--- a/src/validators/default-value-validator.ts
+++ b/src/validators/default-value-validator.ts
@@ -5,15 +5,6 @@ import { codedTypes } from '../constants';
 export const DefaultFieldValueValidator: FormFieldValidator = {
   validate: (field: FormField, value: any) => {
     if (codedTypes.includes(field.questionOptions.rendering)) {
-      // check whether value exists in answers
-      // if (!field.questionOptions.answers?.find((answer) => answer.concept == value)) {
-      //   // eslint-disable-next-line no-console
-      //   console.log(value);
-
-      //   return [
-      //     { resultType: 'error', errCode: 'invalid.defaultValue', message: 'Value not found in coded answers list' },
-      //   ];
-      // }
       if (!value.some((val) => field.questionOptions.answers?.find((answer) => answer.concept === val))) {
         return [
           { resultType: 'error', errCode: 'invalid.defaultValue', message: 'Value not found in coded answers list' },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The [default field validation](https://github.com/openmrs/openmrs-form-engine-lib/blob/40ec1b3fcd3132735fe8d8840aed851d3d1f740b/src/validators/default-value-validator.ts#L7-L14) is only looking at the scenario when the value is an array of one element , however for the case of the checkbox and multi-checbox the value will have more than one element ie  ['30e2da8f-34ca-4c93-94c8-d429f22d381c', '1e2918fb-4e15-11e4-8a57-0800271c1b75'] which causes Value not found in coded answers list error to be displayed as seen in the screenshot below yet both coded values are present in the answers coded list. We need to cater for multi-select fields to
## Screenshots
<img width="627" alt="Screenshot 2024-05-06 at 11 27 21 PM" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/46714226/a97a548b-5d17-4d9e-8540-c9c66902daeb">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
