### PR TITLE
(fix) Multi-select component to initialise and display consistently in edit mode

### DIFF
--- a/src/components/inputs/multi-select/multi-select.component.tsx
+++ b/src/components/inputs/multi-select/multi-select.component.tsx
@@ -41,17 +41,11 @@ const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
     }));
 
   const initiallySelectedQuestionItems = useMemo(() => {
-    let selectedItems = [];
     if (isFieldInitializationComplete && field.value?.length && counter < 1) {
-      selectOptions.forEach((item) => {
-        if (field.value?.includes(item.concept)) {
-          selectedItems.push(item);
-        }
-      });
-      // re-mounts Carbon's MultiSelect component to pickup the initially selected items
       setCounter(counter + 1);
+      return selectOptions.filter((item) => field.value?.includes(item.concept));
     }
-    return selectedItems;
+    return [];
   }, [isFieldInitializationComplete, field.value]);
 
   const handleSelectItemsChange = ({ selectedItems }) => {


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This aims to fix an issue with the multi-select component where it doesn't preselect previously selected values while in edit mode. 

## Screenshots
<!-- Required if you are making UI changes. -->
https://www.loom.com/share/6a7b2ac48ff7430ba25e6a75da42c1d3

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-3135
## Other
<!-- Anything not covered above -->
