### PR TITLE
(fix) O3-2168: Concept reference chunk size depends on REST `webservices.rest.maxResultsCount` property

### DIFF
--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -77,6 +77,8 @@ jest.mock('../src/api/api', () => {
   };
 });
 
+jest.mock('./hooks/useRestMaxResultsCount', () => jest.fn().mockReturnValue({ systemSetting: { value: '50' } }));
+
 describe('Form engine component', () => {
   const user = userEvent.setup();
 

--- a/src/hooks/useConcepts.tsx
+++ b/src/hooks/useConcepts.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { type FetchResponse, type OpenmrsResource, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWRInfinite from 'swr/infinite';
-import { useSystemSetting } from './useSystemSetting';
+import useRestMaxResultsCount from './useRestMaxResultsCount';
 
 type ConceptFetchResponse = FetchResponse<{ results: Array<OpenmrsResource> }>;
 
@@ -13,9 +13,7 @@ export function useConcepts(references: Set<string>): {
   isLoading: boolean;
   error: Error | undefined;
 } {
-  const { isLoading: isLoadingMaxResultsDefault, systemSetting } = useSystemSetting(
-    'webservices.rest.maxResultsDefault',
-  );
+  const { isLoading: isLoadingMaxResultsDefault, systemSetting } = useRestMaxResultsCount();
   const chunkSize = systemSetting?.value ? parseInt(systemSetting.value) : null;
   const totalCount = references.size;
   const totalPages = Math.ceil(totalCount / chunkSize);

--- a/src/hooks/useRestMaxResultsCount.ts
+++ b/src/hooks/useRestMaxResultsCount.ts
@@ -1,0 +1,5 @@
+import useSystemSetting from './useSystemSetting';
+
+export default function useRestMaxResultsCount() {
+  return useSystemSetting('webservices.rest.maxResultsDefault');
+}

--- a/src/hooks/useSystemSetting.ts
+++ b/src/hooks/useSystemSetting.ts
@@ -1,0 +1,36 @@
+import { openmrsFetch, restBaseUrl, showSnackbar } from '@openmrs/esm-framework';
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import useSWRImmutable from 'swr/immutable';
+
+export interface SystemSetting {
+  uuid: string;
+  property: string;
+  value: string;
+}
+
+export function useSystemSetting(setting: string) {
+  const { t } = useTranslation();
+  const apiUrl = `${restBaseUrl}/systemsetting/${setting}?v=custom:(value)`;
+  const { data, error, isLoading } = useSWRImmutable<{ data: SystemSetting }, Error>(apiUrl, openmrsFetch);
+
+  useEffect(() => {
+    if (error) {
+      showSnackbar({
+        title: t('error', 'Error'),
+        subtitle: error?.message,
+        kind: 'error',
+        isLowContrast: false,
+      });
+    }
+  }, [error]);
+
+  return {
+    systemSetting: data?.data,
+    error: error,
+    isLoading: isLoading,
+    isValueUuid:
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(data?.data?.value) ||
+      /^[0-9a-f]{36}$/i.test(data?.data?.value),
+  };
+}

--- a/src/hooks/useSystemSetting.ts
+++ b/src/hooks/useSystemSetting.ts
@@ -9,7 +9,7 @@ export interface SystemSetting {
   value: string;
 }
 
-export function useSystemSetting(setting: string) {
+export default function useSystemSetting(setting: string) {
   const { t } = useTranslation();
   const apiUrl = `${restBaseUrl}/systemsetting/${setting}?v=custom:(value)`;
   const { data, error, isLoading } = useSWRImmutable<{ data: SystemSetting }, Error>(apiUrl, openmrsFetch);

--- a/src/utils/form-helper.ts
+++ b/src/utils/form-helper.ts
@@ -173,7 +173,7 @@ export function findConceptByReference(reference: string, concepts) {
   } else {
     // handle uuid
     return concepts?.find((concept) => {
-      return concept?.uuid === reference;
+      return concept.uuid === reference;
     });
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

The count of concepts in a form can exceed the maximum results returned by the REST module. Hence, we use the global property `webservices.rest.maxResultsCount` system setting, defining the maximum results count the REST module can deliver in a single result.

Hence we create the chunks of UUIDs in the size of the value returned by the above mentioned system settings and fetch the results accordingly.


### Test fix
This PR reverts the change made in **form-helper** in #241. 

For the URLs where the response is not mocked, the `openmrsFetch` returns `undefined` in the tests, which when read by `useSWRInfinite` maps the response to `[ undefined ]`, which then breaks the function written in the form-helper (link mentioned above).

```
Error: Cannot read `uuid` of undefined
```

## Screenshots
None

## Related Issue
None

## Other
<!-- Anything not covered above -->
