### PR TITLE
(fix) Fix conditional access check affecting patientIdentifier type fields 

### DIFF
--- a/src/utils/patient-identifier-helper.ts
+++ b/src/utils/patient-identifier-helper.ts
@@ -11,8 +11,8 @@ export const saveIdentifier = (patient: fhir.Patient, patientIdentifier: Patient
 };
 
 export const getPatientLatestIdentifier = (patient: fhir.Patient, identifierType: string) => {
-  const patientIdentifiers = patient.identifier;
-  return patientIdentifiers.find((identifier) => {
+  const patientIdentifiers = patient?.identifier;
+  return patientIdentifiers?.find((identifier) => {
     if (identifier.type.coding && identifier.type.coding[0].code === identifierType) {
       return true;
     }

--- a/src/utils/patient-identifier-helper.ts
+++ b/src/utils/patient-identifier-helper.ts
@@ -11,8 +11,7 @@ export const saveIdentifier = (patient: fhir.Patient, patientIdentifier: Patient
 };
 
 export const getPatientLatestIdentifier = (patient: fhir.Patient, identifierType: string) => {
-  const patientIdentifiers = patient?.identifier;
-  return patientIdentifiers?.find((identifier) => {
+  return patient?.identifier?.find((identifier) => {
     if (identifier.type.coding && identifier.type.coding[0].code === identifierType) {
       return true;
     }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR is addressing the issue whereby after saving a form of patient identifier type, upon subsequent attempts to reload the form in the form-renderer the schema fails to load.
## Screenshots
https://www.loom.com/share/7d5e92a9e98c423cb05270701f7539cb
## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
