### PR TITLE
(fix) O3-3164 switch to openmrsFetch to fetch encounter

### DIFF
--- a/src/components/encounter/encounter-form.component.tsx
+++ b/src/components/encounter/encounter-form.component.tsx
@@ -26,7 +26,7 @@ import { getPreviousEncounter } from '../../api/api';
 import { isTrue } from '../../utils/boolean-utils';
 import { FieldValidator, isEmpty } from '../../validators/form-validator';
 import { scrollIntoView } from '../../utils/scroll-into-view';
-import { getEncounter } from '../../hooks/useEncounter';
+import { useEncounter } from '../../hooks/useEncounter';
 import { useInitialValues } from '../../hooks/useInitialValues';
 import { useEncounterRole } from '../../hooks/useEncounterRole';
 import { useConcepts } from '../../hooks/useConcepts';
@@ -88,8 +88,7 @@ const EncounterForm: React.FC<EncounterFormProps> = ({
   const [encounterLocation, setEncounterLocation] = useState(null);
   const [encounterDate, setEncounterDate] = useState(formSessionDate);
   const [encounterProvider, setEncounterProvider] = useState(provider);
-  const [encounter, setEncounter] = useState<OpenmrsEncounter>(null);
-  const [isLoadingEncounter, setIsLoadingEncounter] = useState(true);
+  const { encounter, isLoading: isLoadingEncounter } = useEncounter(formJson);
   const [previousEncounter, setPreviousEncounter] = useState<OpenmrsEncounter>(null);
   const [isLoadingPreviousEncounter, setIsLoadingPreviousEncounter] = useState(true);
   const [form, setForm] = useState<FormSchema>(formJson);
@@ -173,13 +172,6 @@ const EncounterForm: React.FC<EncounterFormProps> = ({
     encounterContext,
     formFieldHandlers,
   );
-
-  useEffect(() => {
-    getEncounter(formJson).then((data) => {
-      setEncounter(data.encounter);
-      setIsLoadingEncounter(data.isLoading);
-    });
-  }, [formJson]);
 
   useEffect(() => {
     if (tempInitialValues) {

--- a/src/components/encounter/encounter-form.component.tsx
+++ b/src/components/encounter/encounter-form.component.tsx
@@ -26,7 +26,7 @@ import { getPreviousEncounter } from '../../api/api';
 import { isTrue } from '../../utils/boolean-utils';
 import { FieldValidator, isEmpty } from '../../validators/form-validator';
 import { scrollIntoView } from '../../utils/scroll-into-view';
-import { useEncounter } from '../../hooks/useEncounter';
+import { getEncounter } from '../../hooks/useEncounter';
 import { useInitialValues } from '../../hooks/useInitialValues';
 import { useEncounterRole } from '../../hooks/useEncounterRole';
 import { useConcepts } from '../../hooks/useConcepts';
@@ -88,7 +88,8 @@ const EncounterForm: React.FC<EncounterFormProps> = ({
   const [encounterLocation, setEncounterLocation] = useState(null);
   const [encounterDate, setEncounterDate] = useState(formSessionDate);
   const [encounterProvider, setEncounterProvider] = useState(provider);
-  const { encounter, isLoading: isLoadingEncounter } = useEncounter(formJson);
+  const [encounter, setEncounter] = useState<OpenmrsEncounter>(null);
+  const [isLoadingEncounter, setIsLoadingEncounter] = useState(true);
   const [previousEncounter, setPreviousEncounter] = useState<OpenmrsEncounter>(null);
   const [isLoadingPreviousEncounter, setIsLoadingPreviousEncounter] = useState(true);
   const [form, setForm] = useState<FormSchema>(formJson);
@@ -172,6 +173,13 @@ const EncounterForm: React.FC<EncounterFormProps> = ({
     encounterContext,
     formFieldHandlers,
   );
+
+  useEffect(() => {
+    getEncounter(formJson).then((data) => {
+      setEncounter(data.encounter);
+      setIsLoadingEncounter(data.isLoading);
+    });
+  }, [formJson]);
 
   useEffect(() => {
     if (tempInitialValues) {

--- a/src/hooks/useEncounter.tsx
+++ b/src/hooks/useEncounter.tsx
@@ -23,8 +23,9 @@ export function useEncounter(formJson: FormSchema) {
     } else if (!isEmpty(formJson.encounter)) {
       setEncounter(formJson.encounter as OpenmrsEncounter);
       setIsLoading(false);
+    } else {
+      setIsLoading(false);
     }
-    setIsLoading(false);
   }, [formJson.encounter]);
 
   return { encounter: encounter, error, isLoading };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Switches useEncounter from `useSWR` to `openmrsFecth`. Whereas this had some performance benefits, it’s at the cost of loading stale data. renamed the hook from `useEncounter` to `getEncounter`

## Screenshots

https://github.com/openmrs/openmrs-form-engine-lib/assets/15266028/925e23ac-da5a-49e7-a6fd-f64152ebb363

## Related Issue
https://openmrs.atlassian.net/browse/O3-3164

## Other
<!-- Anything not covered above -->
