### PR TITLE
(chore) Bump @types/react and formik

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openmrs/openmrs-form-engine-lib",
   "version": "2.0.0",
-  "description": "A React based Forms Engine for OpenMRS 3.X",
+  "description": "React Form Engine for O3",
   "browser": "dist/openmrs-form-engine-lib.js",
   "main": "src/index.ts",
   "license": "MIT",
@@ -10,6 +10,7 @@
     "lint": "eslint src --ext .ts,.tsx --fix",
     "verify": "turbo lint typescript test --concurrency=5",
     "test": "jest --config ./jest.config.js --passWithNoTests",
+    "typescript": "tsc",
     "build": "webpack --mode production",
     "coverage": "yarn test --coverage",
     "analyze": "webpack --mode=production --env.analyze=true",
@@ -30,7 +31,7 @@
     "ace-builds": "^1.4.12",
     "classnames": "^2.5.1",
     "dayjs": "1.x",
-    "formik": "^2.2.6",
+    "formik": "^2.4.6",
     "lodash-es": "^4.17.15",
     "react-error-boundary": "^4.0.11",
     "react-markdown": "^7.1.0",
@@ -63,7 +64,7 @@
     "@types/jest": "^29.5.11",
     "@types/lodash": "^4.14.182",
     "@types/lodash-es": "^4.17.3",
-    "@types/react": "^18.2.22",
+    "@types/react": "^18.3.2",
     "@types/webpack-env": "^1.15.1",
     "@types/yup": "^0.29.11",
     "@typescript-eslint/eslint-plugin": "^7.5.0",
@@ -105,8 +106,5 @@
     "*.{ts,tsx}": "eslint --cache --fix --max-warnings 0",
     "*.{css,scss,ts,tsx}": "prettier --write --list-different"
   },
-  "packageManager": "yarn@4.2.2",
-  "resolutions": {
-    "@types/react": "18.2.22"
-  }
+  "packageManager": "yarn@4.2.2"
 }

--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Form, Formik } from 'formik';
 import classNames from 'classnames';
+import { Form, Formik } from 'formik';
 import { Button, ButtonSet, InlineLoading } from '@carbon/react';
 import { I18nextProvider, useTranslation } from 'react-i18next';
 import * as Yup from 'yup';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3225,7 +3225,7 @@ __metadata:
     "@types/jest": "npm:^29.5.11"
     "@types/lodash": "npm:^4.14.182"
     "@types/lodash-es": "npm:^4.17.3"
-    "@types/react": "npm:^18.2.22"
+    "@types/react": "npm:^18.3.2"
     "@types/webpack-env": "npm:^1.15.1"
     "@types/yup": "npm:^0.29.11"
     "@typescript-eslint/eslint-plugin": "npm:^7.5.0"
@@ -3240,7 +3240,7 @@ __metadata:
     eslint-plugin-jsx-a11y: "npm:^6.5.1"
     eslint-plugin-react-hooks: "npm:^4.3.0"
     fork-ts-checker-webpack-plugin: "npm:^6.3.3"
-    formik: "npm:^2.2.6"
+    formik: "npm:^2.4.6"
     husky: "npm:^8.0.0"
     i18next: "npm:^23.11.2"
     i18next-parser: "npm:^8.13.0"
@@ -4830,6 +4830,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hoist-non-react-statics@npm:^3.3.1":
+  version: 3.3.5
+  resolution: "@types/hoist-non-react-statics@npm:3.3.5"
+  dependencies:
+    "@types/react": "npm:*"
+    hoist-non-react-statics: "npm:^3.3.0"
+  checksum: 10/b645b062a20cce6ab1245ada8274051d8e2e0b2ee5c6bd58215281d0ec6dae2f26631af4e2e7c8abe238cdcee73fcaededc429eef569e70908f82d0cc0ea31d7
+  languageName: node
+  linkType: hard
+
 "@types/html-minifier-terser@npm:^6.0.0":
   version: 6.1.0
   resolution: "@types/html-minifier-terser@npm:6.1.0"
@@ -5026,14 +5036,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:18.2.22":
-  version: 18.2.22
-  resolution: "@types/react@npm:18.2.22"
+"@types/react@npm:*, @types/react@npm:^18.3.2":
+  version: 18.3.2
+  resolution: "@types/react@npm:18.3.2"
   dependencies:
     "@types/prop-types": "npm:*"
-    "@types/scheduler": "npm:*"
     csstype: "npm:^3.0.2"
-  checksum: 10/a9579ed16492fb08266adb98377bf4b8b6ce2078e8fe19be0bbca3fbea15ec8a9fde9828420192458be7bef6e63f9509ce92c7b8c890ce2973ff40b7091302e6
+  checksum: 10/a85eed82c1009dc9d979281d9ea1f5322255003de3378390f35d897b4bdaf1d34ea748636c03e9e9b4b7cc97c2f4582993d2d60e40846226ad497d97c7d8565a
   languageName: node
   linkType: hard
 
@@ -5059,13 +5068,6 @@ __metadata:
   version: 0.12.0
   resolution: "@types/retry@npm:0.12.0"
   checksum: 10/bbd0b88f4b3eba7b7acfc55ed09c65ef6f2e1bcb4ec9b4dca82c66566934351534317d294a770a7cc6c0468d5573c5350abab6e37c65f8ef254443e1b028e44d
-  languageName: node
-  linkType: hard
-
-"@types/scheduler@npm:*":
-  version: 0.23.0
-  resolution: "@types/scheduler@npm:0.23.0"
-  checksum: 10/874d753aa65c17760dfc460a91e6df24009bde37bfd427a031577b30262f7770c1b8f71a21366c7dbc76111967384cf4090a31d65315155180ef14bd7acccb32
   languageName: node
   linkType: hard
 
@@ -9468,20 +9470,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"formik@npm:^2.2.6":
-  version: 2.2.9
-  resolution: "formik@npm:2.2.9"
+"formik@npm:^2.4.6":
+  version: 2.4.6
+  resolution: "formik@npm:2.4.6"
   dependencies:
+    "@types/hoist-non-react-statics": "npm:^3.3.1"
     deepmerge: "npm:^2.1.1"
     hoist-non-react-statics: "npm:^3.3.0"
     lodash: "npm:^4.17.21"
     lodash-es: "npm:^4.17.21"
     react-fast-compare: "npm:^2.0.1"
     tiny-warning: "npm:^1.0.2"
-    tslib: "npm:^1.10.0"
+    tslib: "npm:^2.0.0"
   peerDependencies:
     react: ">=16.8.0"
-  checksum: 10/c7b4c6ee9cc8256302c56106fa4ff1a86b48774b26e5cdd4fe5a40d5ae2171ed7a02714cd36fa7fb05d8b86c5471643339a69d6e3f4234a963e70b9208cbee82
+  checksum: 10/65d6845d913cfceebdbb1e34d498725965e07abd4c17f3ea9eeba77d9fab7d3b0f726fdfcae73f002b660ba56b236abc8d8aa6670a9c7cc0db27afebf6e48f4b
   languageName: node
   linkType: hard
 
@@ -16773,14 +16776,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.10.0, tslib@npm:^1.9.0":
+"tslib@npm:^1.9.0":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 10/7dbf34e6f55c6492637adb81b555af5e3b4f9cc6b998fb440dac82d3b42bdc91560a35a5fb75e20e24a076c651438234da6743d139e4feabf0783f3cdfe1dddb
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.3, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 10/bd26c22d36736513980091a1e356378e8b662ded04204453d353a7f34a4c21ed0afc59b5f90719d4ba756e581a162ecbf93118dc9c6be5acf70aa309188166ca


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Bumps the @types/react and formik versions to the latest available releases. Bumping @types/react means we don't have to rely on [selective dependency resolutions](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/) and we can use the same version of it everywhere this library is used. Bumping [formik](https://github.com/jaredpalmer/formik/releases/tag/formik%402.4.6) fixes issues with outdated type annotations. This PR should be merged with related PRs in Form Builder and Patient Chart.

This PR also adds a `typescript` script to the manifest file that runs the typescript compiler to check types. 
 
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
