### PR TITLE
(feat) Form engine UI improvements

### DIFF
--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -1,18 +1,17 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import dayjs from 'dayjs';
-import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useField } from 'formik';
 import { DatePicker, DatePickerInput, Layer, TimePicker } from '@carbon/react';
-import { isTrue } from '../../../utils/boolean-utils';
 import { type FormFieldProps } from '../../../types';
+import { isTrue } from '../../../utils/boolean-utils';
 import { isInlineView } from '../../../utils/form-helper';
 import { isEmpty } from '../../../validators/form-validator';
 import { FormContext } from '../../../form-context';
+import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 import FieldValueView from '../../value/view/field-value-view.component';
 import RequiredFieldLabel from '../../required-field-label/required-field-label.component';
 import styles from './date.scss';
-import { useFieldValidationResults } from '../../../hooks/useFieldValidationResults';
 
 const locale = window.i18next.language == 'en' ? 'en-GB' : window.i18next.language;
 const dateFormatter = new Intl.DateTimeFormat(locale);
@@ -126,7 +125,7 @@ const DateField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
               <DatePicker
                 datePickerType="single"
                 onChange={onDateChange}
-                className={classNames(styles.boldedLabel)}
+                className={styles.boldedLabel}
                 dateFormat={carbonDateFormat}>
                 <DatePickerInput
                   id={question.id}

--- a/src/components/loaders/loader.scss
+++ b/src/components/loaders/loader.scss
@@ -1,5 +1,12 @@
 .loaderContainer {
-  height: calc(100vh - var(--omrs-navbar-height) - var(--workspace-header-height));
+  height: var(--desktop-workspace-window-height);
+}
+
+// tablet
+:global(.omrs-breakpoint-lt-desktop) {
+  .loaderContainer {
+    height: var(--tablet-workspace-window-height);
+  }
 }
 
 .loader {

--- a/src/components/sidebar/sidebar.component.tsx
+++ b/src/components/sidebar/sidebar.component.tsx
@@ -91,7 +91,7 @@ const Sidebar = ({
           )
         );
       })}
-      {mode !== 'view' && <hr className={styles.sideBarHorizontalLine} />}
+      {mode !== 'view' && <hr className={styles.divider} />}
       <div className={styles.sidenavActions}>
         {allowUnspecifiedAll && mode !== 'view' && (
           <div style={{ marginBottom: '.6rem' }}>

--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -37,14 +37,13 @@
   letter-spacing: 0.16px;
   color: colors.$gray-100;
   cursor: pointer;
+
+  :hover {
+    outline: none;
+  }
 }
 
-.link:hover {
-  outline: none;
-}
-
-// Sidebar-Section
-.sidebarSection {
+.section {
   border-left: 0.5rem solid colors.$teal-20;
   display: flex;
   align-items: center;
@@ -54,41 +53,69 @@
   cursor: pointer;
 }
 
-.sidebarSectionLink {
+/* Tablet */
+:global(.omrs-breakpoint-lt-desktop) {
+  .section {
+    height: 3rem;
+  }
+}
+
+.sectionLink {
   @include type.type-style('body-01');
   color: colors.$gray-100;
 }
 
-.sidebarSectionActive {
-  @extend .sidebarSection;
+.activeSection {
+  @extend .section;
   border-left: 0.5rem solid colors.$teal-50;
   background-color: #ededed;
 
-  .sidebarSectionLink {
+  .sectionLink {
     font-weight: 600;
   }
 }
 
-.sidebarSectionDone {
-  @extend .sidebarSection;
+.sectionDone {
+  @extend .section;
   border-left: 0.5rem solid colors.$teal-80;
   background-color: colors.$green-10;
 }
 
-.sidebarSectionError {
-  @extend .sidebarSection;
+.erroredSection {
+  @extend .section;
   border-left: 0.5rem solid colors.$red-60;
   color: colors.$red-70 !important;
   background-color: colors.$red-20;
 }
 
-.sidebarSectionErrorActive {
-  @extend .sidebarSectionError;
+.activeErroredSection {
+  @extend .erroredSection;
   font-weight: 600;
 }
 
 .divider {
   border: 0;
-  border-top: 0.5px solid colors.$gray-40;
-  margin: 1rem 0.5rem;
+  border-top: 1px solid colors.$gray-40;
+  margin: 2.5rem 0.5rem 1rem;
+}
+
+.button {
+  width: 11rem;
+}
+
+.topMargin {
+  margin-top: 1.5rem;
+}
+
+.saveButton {
+  @extend .button;
+  margin-bottom: 0.625rem;
+}
+
+.closeButton {
+  @extend .button;
+}
+
+.toggleContainer {
+  margin-bottom: 0.5rem;
 }

--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -1,10 +1,11 @@
 @use '@carbon/colors';
+@use '@carbon/type';
 
 .sidebar {
   width: 12rem;
   min-height: 8rem;
   overscroll-behavior: contain;
-  margin: 1px 13px 15px 0;
+  margin-right: 1rem;
 }
 
 .sidebarList {
@@ -44,64 +45,50 @@
 
 // Sidebar-Section
 .sidebarSection {
-  border-left: 0.5rem solid var(--brand-03);
-  height: auto;
-  margin: 0.122rem 0 0.122rem;
-  padding: 0.382rem 0.375rem 0.118rem 1rem;
-  background-color: white;
-  cursor: pointer;
-}
-
-.sidebarSectionActive {
-  border-left: 0.5rem solid var(--brand-01);
-  height: auto;
-  font-weight: 600;
-  margin: 0.122rem 0 0.122rem;
-  padding: 0.382rem 0.375rem 0.118rem 1rem;
-  background-color: #ededed;
-  cursor: pointer;
-}
-
-.sidebarSectionDone {
-  border-left: 0.5rem solid var(--brand-02);
-  height: auto;
-  margin: 0.122rem 0 0.122rem;
-  padding: 0.382rem 0.375rem 0.118rem 1rem;
-  background-color: colors.$green-10;
-  cursor: pointer;
-}
-
-.sidebarSectionError {
-  border-left: 0.5rem solid colors.$red-60;
-  height: auto;
-  color: colors.$red-70 !important;
-  margin: 0.122rem 0 0.122rem;
-  padding: 0.382rem 0.375rem 0.118rem 1rem;
-  background-color: colors.$red-20;
-  cursor: pointer;
-}
-
-.sidebarSectionErrorActive {
-  @extend .sidebarSectionError;
-  border-left: 0.5rem solid colors.$red-60;
-  height: auto;
-  font-weight: 600;
-  color: colors.$red-70 !important;
-  margin: 0.122rem 0 0.122rem;
-  padding: 0.382rem 0.375rem 0.118rem 1rem;
-  background-color: colors.$red-20;
+  border-left: 0.5rem solid colors.$teal-20;
+  display: flex;
+  align-items: center;
+  height: 2rem;
+  padding: 0.25rem 0.5rem;
+  background-color: colors.$white;
   cursor: pointer;
 }
 
 .sidebarSectionLink {
-  font-size: 0.875rem;
-  font-stretch: normal;
-  font-style: normal;
-  line-height: 1.43;
-  letter-spacing: 0.16px;
+  @include type.type-style('body-01');
   color: colors.$gray-100;
 }
 
-.sideBarHorizontalLine {
-  margin-top: 1.5rem;
+.sidebarSectionActive {
+  @extend .sidebarSection;
+  border-left: 0.5rem solid colors.$teal-50;
+  background-color: #ededed;
+
+  .sidebarSectionLink {
+    font-weight: 600;
+  }
+}
+
+.sidebarSectionDone {
+  @extend .sidebarSection;
+  border-left: 0.5rem solid colors.$teal-80;
+  background-color: colors.$green-10;
+}
+
+.sidebarSectionError {
+  @extend .sidebarSection;
+  border-left: 0.5rem solid colors.$red-60;
+  color: colors.$red-70 !important;
+  background-color: colors.$red-20;
+}
+
+.sidebarSectionErrorActive {
+  @extend .sidebarSectionError;
+  font-weight: 600;
+}
+
+.divider {
+  border: 0;
+  border-top: 0.5px solid colors.$gray-40;
+  margin: 1rem 0.5rem;
 }

--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -251,17 +251,17 @@ const FormEngine: React.FC<FormProps> = ({
         setIsFormDirty(props.dirty);
 
         return (
-          <Form className={classNames('cds--form', 'no-padding', styles.formEngine)} ref={ref}>
+          <Form className={classNames('cds--form', styles.formEngine)} ref={ref}>
             {isLoadingPatient || isLoadingFormJson ? (
               <Loader />
             ) : (
-              <div className={styles.formEngineContainer}>
+              <div className={styles.container}>
                 {isLoadingFormDependencies && (
                   <div className={styles.linearActivity}>
                     <div className={styles.indeterminate}></div>
                   </div>
                 )}
-                <div className={styles.formEngineBody}>
+                <div className={styles.body}>
                   {showSidebar && (
                     <Sidebar
                       isFormSubmitting={isSubmitting}
@@ -278,17 +278,14 @@ const FormEngine: React.FC<FormProps> = ({
                       hideFormCollapseToggle={hideFormCollapseToggle}
                     />
                   )}
-                  <div className={styles.formContent}>
+                  <div className={styles.content}>
                     {showPatientBanner && <PatientBanner patient={patient} hideActionsOverflow />}
                     {refinedFormJson.markdown && (
                       <div className={styles.markdownContainer}>
                         <MarkdownWrapper markdown={refinedFormJson.markdown} />
                       </div>
                     )}
-                    <div
-                      className={classNames(styles.formContentBody, {
-                        [styles.minifiedFormContentBody]: workspaceLayout === 'minimized' || sessionMode === 'view',
-                      })}>
+                    <div className={classNames(styles.contentBody)}>
                       <EncounterForm
                         formJson={refinedFormJson}
                         patient={patient}

--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -285,7 +285,7 @@ const FormEngine: React.FC<FormProps> = ({
                         <MarkdownWrapper markdown={refinedFormJson.markdown} />
                       </div>
                     )}
-                    <div className={classNames(styles.contentBody)}>
+                    <div className={styles.contentBody}>
                       <EncounterForm
                         formJson={refinedFormJson}
                         patient={patient}

--- a/src/form-engine.scss
+++ b/src/form-engine.scss
@@ -61,6 +61,7 @@
   }
 
   .minifiedButtons {
+    border-top: 1px solid #ededed;
     padding: 1.5rem 1rem;
     background-color: white;
   }

--- a/src/form-engine.scss
+++ b/src/form-engine.scss
@@ -4,21 +4,21 @@
   flex-grow: 1;
 }
 
-.formEngineContainer {
+.container {
   display: flex;
   height: 100%;
   overflow-y: hidden;
   flex-direction: column;
 }
 
-.formEngineBody {
+.body {
   display: flex;
   flex-direction: row;
   height: 100%;
 }
 
 .loader {
-  @extend .formEngineBody;
+  @extend .body;
   height: 1rem;
 }
 
@@ -26,8 +26,8 @@
   font-size: 0.875rem;
 }
 
-.formContent {
-  height: calc(100vh - 6rem);
+.content {
+  height: var(--desktop-workspace-window-height);
   margin: 0;
   flex-basis: 65%;
   flex-grow: 1;
@@ -36,32 +36,34 @@
   overflow-y: hidden;
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
 }
 
-.formContentBody {
+.contentBody {
   overflow-y: auto;
   width: inherit;
   position: sticky;
 }
 
-.minifiedFormContentBody {
-  margin-bottom: 4rem !important;
-}
-
 .minifiedButtons {
-  width: 100%;
-  height: 63.5px;
-  position: absolute;
-  bottom: 0;
+  button {
+    height: 4rem;
+    display: flex;
+    align-content: flex-start;
+    align-items: baseline;
+    min-width: 50%;
+  }
 }
 
-.minifiedButtons :global(.cds--btn) {
-  max-width: 50%;
-  height: 3.9rem;
-}
+:global(.omrs-breakpoint-lt-desktop) {
+  .content {
+    height: var(--tablet-workspace-window-height);
+  }
 
-.minifiedButtons > button {
-  width: 50%;
+  .minifiedButtons {
+    padding: 1.5rem 1rem;
+    background-color: white;
+  }
 }
 
 .markdownContainer {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR applies various fixes to the form engine UI, including:

- Fixing the form layout in the tablet viewport
- Making several tweaks to align with the available designs [here](https://zpl.io/JEkGxlr) and [here](https://zeroheight.com/23a080e38/p/9014c5-form-navigation). 

## Screenshots

### Before

#### Tablet 

![CleanShot 2024-05-20 at 9  40 29 2@2x](https://github.com/openmrs/openmrs-form-engine-lib/assets/8509731/9686fa67-df3c-41eb-940c-36b9783bcee5)

#### Desktop (maximized) - the sidebar doesn't quite match the designs

![CleanShot 2024-05-20 at 11  10 05@2x](https://github.com/openmrs/openmrs-form-engine-lib/assets/8509731/20d14844-0cff-4c83-bb14-82d52968f45b)

### After

#### Tablet 

![CleanShot 2024-05-20 at 10  58 28@2x](https://github.com/openmrs/openmrs-form-engine-lib/assets/8509731/561bc0bd-8ff6-43cd-8634-922e7b71c0a1)

#### Desktop

![CleanShot 2024-05-20 at 10  57 49@2x](https://github.com/openmrs/openmrs-form-engine-lib/assets/8509731/c58d1cb3-55b6-4257-8de9-a6117337e795)

#### Desktop (maximized) - the sidebar aligned with the designs

![CleanShot 2024-05-20 at 10  58 11@2x](https://github.com/openmrs/openmrs-form-engine-lib/assets/8509731/05b6d012-e359-4360-bf7c-66a4757db80b)

## Related Issue

https://openmrs.atlassian.net/browse/O3-3252

## Other
<!-- Anything not covered above -->
