### PR TITLE
(refactor) Colocate EncounterForm state

### DIFF
--- a/src/external-function-context.tsx
+++ b/src/external-function-context.tsx
@@ -1,8 +1,13 @@
-import React from 'react';
+import { createContext } from 'react';
 import type { FormField } from './types';
 
-export type ExternalFunctionContextProps = {
+/**
+ * Context to pass callback functions from frontend modules to the form engine.
+ * This context allows the form engine to access functions defined in the consuming
+ * modules, facilitating interactions such as confirming the deletion of a form question.
+ */
+export type ExternalFunctionContextType = {
   handleConfirmQuestionDeletion: (question: Readonly<FormField>) => Promise<void>;
 };
 
-export const ExternalFunctionContext = React.createContext<ExternalFunctionContextProps | undefined>(undefined);
+export const ExternalFunctionContext = createContext<ExternalFunctionContextType | undefined>(undefined);

--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -4,24 +4,23 @@ import { Form, Formik } from 'formik';
 import { Button, ButtonSet, InlineLoading } from '@carbon/react';
 import { I18nextProvider, useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
-import { showSnackbar, useSession, type Visit } from '@openmrs/esm-framework';
+import { showSnackbar, type Visit } from '@openmrs/esm-framework';
 import { init, teardown } from './lifecycle';
 import type { FormField, FormPage as FormPageProps, FormSchema, SessionMode } from './types';
 import { extractErrorMessagesFromResponse, reportError } from './utils/error-utils';
-import { useFormJson } from './hooks/useFormJson';
-import { usePostSubmissionAction } from './hooks/usePostSubmissionAction';
-import { useWorkspaceLayout } from './hooks/useWorkspaceLayout';
-import { usePatientData } from './hooks/usePatientData';
 import { evaluatePostSubmissionExpression } from './utils/post-submission-action-helper';
+import { ExternalFunctionContext } from './external-function-context';
 import { moduleName } from './globals';
 import { useFormCollapse } from './hooks/useFormCollapse';
-import { useEncounterRole } from './hooks/useEncounterRole';
+import { useFormJson } from './hooks/useFormJson';
+import { usePatientData } from './hooks/usePatientData';
+import { usePostSubmissionAction } from './hooks/usePostSubmissionAction';
+import { useWorkspaceLayout } from './hooks/useWorkspaceLayout';
 import EncounterForm from './components/encounter/encounter-form.component';
 import Loader from './components/loaders/loader.component';
 import MarkdownWrapper from './components/inputs/markdown/markdown-wrapper.component';
 import PatientBanner from './components/patient-banner/patient-banner.component';
 import Sidebar from './components/sidebar/sidebar.component';
-import { ExternalFunctionContext } from './external-function-context';
 import styles from './form-engine.scss';
 
 interface FormProps {
@@ -72,25 +71,21 @@ export interface FormSubmissionHandler {
 }
 
 const FormEngine: React.FC<FormProps> = ({
-  formJson,
-  formUUID,
-  patientUUID,
+  encounterUuid,
   encounterUUID,
-  visit,
-  mode,
-  onSubmit,
-  onCancel,
+  formJson,
+  formSessionIntent,
+  formUUID,
   handleClose,
   handleConfirmQuestionDeletion,
-  formSessionIntent,
-  meta,
-  encounterUuid,
   markFormAsDirty,
+  meta,
+  mode,
+  onCancel,
+  onSubmit,
+  patientUUID,
+  visit,
 }) => {
-  const session = useSession();
-  const { encounterRole } = useEncounterRole();
-  const currentProvider = session?.currentProvider?.uuid ? session.currentProvider.uuid : null;
-  const location = session && !(encounterUUID || encounterUuid) ? session?.sessionLocation : null;
   const { patient, isLoadingPatient: isLoadingPatient, patientError: patientError } = usePatientData(patientUUID);
   const {
     formJson: refinedFormJson,
@@ -99,7 +94,6 @@ const FormEngine: React.FC<FormProps> = ({
   } = useFormJson(formUUID, formJson, encounterUUID || encounterUuid, formSessionIntent);
 
   const { t } = useTranslation();
-  const formSessionDate = useMemo(() => new Date(), []);
   const handlers = new Map<string, FormSubmissionHandler>();
   const ref = useRef(null);
   const workspaceLayout = useWorkspaceLayout(ref);
@@ -119,7 +113,7 @@ const FormEngine: React.FC<FormProps> = ({
   }, [workspaceLayout, scrollablePages.size, sessionMode]);
 
   const showPatientBanner = useMemo(() => {
-    return workspaceLayout != 'minimized' && patient?.id && sessionMode != 'embedded-view';
+    return workspaceLayout !== 'minimized' && patient?.id && sessionMode !== 'embedded-view';
   }, [patient?.id, sessionMode, workspaceLayout]);
 
   const showButtonSet = useMemo(() => {
@@ -268,7 +262,7 @@ const FormEngine: React.FC<FormProps> = ({
                 <div className={styles.container}>
                   {isLoadingFormDependencies && (
                     <div className={styles.linearActivity}>
-                      <div className={styles.indeterminate}></div>
+                      <div className={styles.indeterminate} />
                     </div>
                   )}
                   <div className={styles.body}>
@@ -299,10 +293,6 @@ const FormEngine: React.FC<FormProps> = ({
                         <EncounterForm
                           formJson={refinedFormJson}
                           patient={patient}
-                          formSessionDate={formSessionDate}
-                          provider={currentProvider}
-                          role={encounterRole?.uuid}
-                          location={location}
                           visit={visit}
                           values={props.values}
                           isFormExpanded={isFormExpanded}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR refactors the `FormEngine` and `EncounterForm` components to colocate state as close as possible to where it's used.   This includes:

- Moving the `useSession` call from `FormEngine` down to `EncounterForm`.
- Moving the `useEncounterRole` call to `EncounterForm`.
- Moving the memorized `formSessionDate` down to `Encounter form`.

In all these instances, these pieces of state are only consumed by `EncounterForm`, so it makes sense to [colocate them there](https://kentcdodds.com/blog/state-colocation-will-make-your-react-app-faster#what-is-colocated-state).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
