### PR TITLE
(fix)03-3338 :Refactor extraction of previous value to the section component.

### DIFF
--- a/src/components/inputs/content-switcher/content-switcher.component.tsx
+++ b/src/components/inputs/content-switcher/content-switcher.component.tsx
@@ -20,7 +20,7 @@ const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, handler
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const { value } = previousValue;
+      const value = previousValue;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, null);
       handler?.handleFieldSubmission(question, value, encounterContext);

--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -40,7 +40,7 @@ const DateField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const date = previousValue.value;
+      const date = previousValue;
       const refinedDate = date instanceof Date ? new Date(date.setHours(0, 0, 0, 0)) : date;
       setFieldValue(question.id, refinedDate);
       onChange(question.id, refinedDate, setErrors, setWarnings);

--- a/src/components/inputs/multi-select/multi-select.component.tsx
+++ b/src/components/inputs/multi-select/multi-select.component.tsx
@@ -50,9 +50,7 @@ const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const previousValues = Array.isArray(previousValue)
-        ? previousValue.map((item) => item.value)
-        : [previousValue.value];
+      const previousValues = Array.isArray(previousValue) ? previousValue.map((item) => item.value) : [previousValue];
       setFieldValue(question.id, previousValues);
       onChange(question.id, previousValues, setErrors, setWarnings);
       handler?.handleFieldSubmission(question, previousValues, encounterContext);

--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -38,7 +38,7 @@ const NumberField: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const { value } = previousValue;
+      const value = previousValue;
       setFieldValue(question.id, value);
       field['value'] = value;
       field.onBlur(null);

--- a/src/components/inputs/radio/radio.component.tsx
+++ b/src/components/inputs/radio/radio.component.tsx
@@ -26,7 +26,7 @@ const Radio: React.FC<FormFieldProps> = ({ question, onChange, handler, previous
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const { value } = previousValue;
+      const value = previousValue;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, setWarnings);
       handler?.handleFieldSubmission(question, value, encounterContext);

--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -26,7 +26,7 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const { value } = previousValue;
+      const value = previousValue;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, setWarnings);
       handler?.handleFieldSubmission(question, value, encounterContext);

--- a/src/components/inputs/text-area/text-area.component.tsx
+++ b/src/components/inputs/text-area/text-area.component.tsx
@@ -33,7 +33,7 @@ const TextArea: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
 
   useEffect(() => {
     if (!isEmpty(previousValueProp)) {
-      const { value } = previousValueProp;
+      const value = previousValueProp;
       setFieldValue(question.id, value);
       field['value'] = value;
     }

--- a/src/components/inputs/text/text.component.tsx
+++ b/src/components/inputs/text/text.component.tsx
@@ -21,7 +21,7 @@ const TextField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const { value } = previousValue;
+      const value = previousValue;
       setFieldValue(question.id, value);
       field['value'] = value;
       field.onBlur(null);

--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -57,7 +57,7 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const { value } = previousValue;
+      const value = previousValue;
       isProcessingSelection.current = true;
       setFieldValue(question.id, value);
       onChange(question.id, value, setErrors, setWarnings);

--- a/src/components/section/form-section.component.tsx
+++ b/src/components/section/form-section.component.tsx
@@ -82,7 +82,7 @@ const FormSection = ({ fields, onFieldChange }) => {
                   key={index}
                   handler={handler}
                   useField={useField}
-                  previousValue={previousValues[fieldDescriptor.id].value}
+                  previousValue={previousValues[fieldDescriptor.id]?.value}
                 />
               );
 

--- a/src/components/section/form-section.component.tsx
+++ b/src/components/section/form-section.component.tsx
@@ -82,7 +82,7 @@ const FormSection = ({ fields, onFieldChange }) => {
                   key={index}
                   handler={handler}
                   useField={useField}
-                  previousValue={previousValues[fieldDescriptor.id]}
+                  previousValue={previousValues[fieldDescriptor.id].value}
                 />
               );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,7 +160,7 @@ export interface FormFieldProps {
   handler: SubmissionHandler;
   // This is of util to components defined out of the engine
   useField?: (fieldId: string) => [FieldInputProps<any>, FieldMetaProps<any>, FieldHelperProps<any>];
-  previousValue?: previousValue;
+  previousValue?: string | number | Date | boolean | previousValue[];
 }
 
 export interface FormSection {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR moves the extraction of the value from the previous value object to happen from the section component, such that only the value is passed down to the input control and not the entire object
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://openmrs.atlassian.net/browse/O3-3338

## Other
<!-- Anything not covered above -->
