### PR TITLE
(refactor) Remove redundant "value" state derived from the "previous value"

### DIFF
--- a/src/components/inputs/content-switcher/content-switcher.component.tsx
+++ b/src/components/inputs/content-switcher/content-switcher.component.tsx
@@ -20,10 +20,9 @@ const ContentSwitcher: React.FC<FormFieldProps> = ({ question, onChange, handler
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const value = previousValue;
-      setFieldValue(question.id, value);
-      onChange(question.id, value, setErrors, null);
-      handler?.handleFieldSubmission(question, value, encounterContext);
+      setFieldValue(question.id, previousValue);
+      onChange(question.id, previousValue, setErrors, null);
+      handler?.handleFieldSubmission(question, previousValue, encounterContext);
     }
   }, [previousValue]);
 

--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -40,8 +40,7 @@ const DateField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const date = previousValue;
-      const refinedDate = date instanceof Date ? new Date(date.setHours(0, 0, 0, 0)) : date;
+      const refinedDate = previousValue instanceof Date ? new Date(previousValue.setHours(0, 0, 0, 0)) : previousValue;
       setFieldValue(question.id, refinedDate);
       onChange(question.id, refinedDate, setErrors, setWarnings);
       onTimeChange(false, true);
@@ -169,8 +168,8 @@ const DateField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
                     time
                       ? time
                       : field.value instanceof Date
-                        ? field.value.toLocaleDateString(window.navigator.language)
-                        : field.value
+                      ? field.value.toLocaleDateString(window.navigator.language)
+                      : field.value
                   }
                   onChange={onTimeChange}
                 />

--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -38,9 +38,8 @@ const NumberField: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const value = previousValue;
-      setFieldValue(question.id, value);
-      field['value'] = value;
+      setFieldValue(question.id, previousValue);
+      field['value'] = previousValue;
       field.onBlur(null);
     }
   }, [previousValue]);

--- a/src/components/inputs/radio/radio.component.tsx
+++ b/src/components/inputs/radio/radio.component.tsx
@@ -26,10 +26,9 @@ const Radio: React.FC<FormFieldProps> = ({ question, onChange, handler, previous
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const value = previousValue;
-      setFieldValue(question.id, value);
-      onChange(question.id, value, setErrors, setWarnings);
-      handler?.handleFieldSubmission(question, value, encounterContext);
+      setFieldValue(question.id, previousValue);
+      onChange(question.id, previousValue, setErrors, setWarnings);
+      handler?.handleFieldSubmission(question, previousValue, encounterContext);
     }
   }, [previousValue]);
 

--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -26,10 +26,9 @@ const Dropdown: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const value = previousValue;
-      setFieldValue(question.id, value);
-      onChange(question.id, value, setErrors, setWarnings);
-      handler?.handleFieldSubmission(question, value, encounterContext);
+      setFieldValue(question.id, previousValue);
+      onChange(question.id, previousValue, setErrors, setWarnings);
+      handler?.handleFieldSubmission(question, previousValue, encounterContext);
     }
   }, [previousValue]);
 

--- a/src/components/inputs/text-area/text-area.component.tsx
+++ b/src/components/inputs/text-area/text-area.component.tsx
@@ -33,9 +33,8 @@ const TextArea: React.FC<FormFieldProps> = ({ question, onChange, handler, previ
 
   useEffect(() => {
     if (!isEmpty(previousValueProp)) {
-      const value = previousValueProp;
-      setFieldValue(question.id, value);
-      field['value'] = value;
+      setFieldValue(question.id, previousValueProp);
+      field['value'] = previousValueProp;
     }
   }, [previousValueProp]);
 

--- a/src/components/inputs/text/text.component.tsx
+++ b/src/components/inputs/text/text.component.tsx
@@ -21,9 +21,8 @@ const TextField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const value = previousValue;
-      setFieldValue(question.id, value);
-      field['value'] = value;
+      setFieldValue(question.id, previousValue);
+      field['value'] = previousValue;
       field.onBlur(null);
     }
   }, [previousValue]);

--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -57,11 +57,10 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
 
   useEffect(() => {
     if (!isEmpty(previousValue)) {
-      const value = previousValue;
       isProcessingSelection.current = true;
-      setFieldValue(question.id, value);
-      onChange(question.id, value, setErrors, setWarnings);
-      handler?.handleFieldSubmission(question, value, encounterContext);
+      setFieldValue(question.id, previousValue);
+      onChange(question.id, previousValue, setErrors, setWarnings);
+      handler?.handleFieldSubmission(question, previousValue, encounterContext);
     }
   }, [previousValue]);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR is removing the redundant `value` state coming from the `previous value` across all components in the engine  
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
