### PR TITLE
(fix) Restrict schema transformer mutations to 'ui-select-extended' rendering on encounter-date fields

### DIFF
--- a/src/transformers/default-schema-transformer.ts
+++ b/src/transformers/default-schema-transformer.ts
@@ -125,7 +125,9 @@ function transformByType(question: FormField) {
       question.questionOptions.rendering = 'encounter-role';
       break;
     case 'encounterDatetime':
-      question.questionOptions.rendering = 'date';
+      question.questionOptions.rendering = hasRendering(question, 'ui-select-extended')
+        ? 'date'
+        : question.questionOptions.rendering;
       break;
   }
 }


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR modifies the schema transformer to only update encounter-date fields with the "ui-select-extended" rendering. This change prevents unintended modifications to other field instances. 

## Screenshots
<!-- Required if you are making UI changes. -->
N/A

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
N/A

## Other
<!-- Anything not covered above -->
N/A
