### PR TITLE
(fix) O3-3378: Revise logic for expanding and collapsing a section

### DIFF
--- a/src/components/encounter/encounter-form.component.tsx
+++ b/src/components/encounter/encounter-form.component.tsx
@@ -47,7 +47,7 @@ interface EncounterFormProps {
   location: SessionLocation;
   visit?: Visit;
   values: Record<string, any>;
-  isFormExpanded: boolean;
+  isFormExpanded: boolean | undefined;
   sessionMode: SessionMode;
   scrollablePages: Set<FormPageProps>;
   handlers: Map<string, FormSubmissionHandler>;

--- a/src/components/encounter/encounter-form.component.tsx
+++ b/src/components/encounter/encounter-form.component.tsx
@@ -2,6 +2,7 @@ import React, { type Dispatch, type SetStateAction, useCallback, useEffect, useM
 import { type SessionLocation, showSnackbar, useLayoutType, type Visit } from '@openmrs/esm-framework';
 import { codedTypes, ConceptFalse, ConceptTrue } from '../../constants';
 import type {
+  FormExpanded,
   FormField,
   FormPage as FormPageProps,
   FormSchema,
@@ -47,7 +48,7 @@ interface EncounterFormProps {
   location: SessionLocation;
   visit?: Visit;
   values: Record<string, any>;
-  isFormExpanded: boolean | undefined;
+  isFormExpanded: FormExpanded;
   sessionMode: SessionMode;
   scrollablePages: Set<FormPageProps>;
   handlers: Map<string, FormSubmissionHandler>;

--- a/src/components/page/form-page.component.tsx
+++ b/src/components/page/form-page.component.tsx
@@ -6,6 +6,7 @@ import FormSection from '../section/form-section.component';
 import { FormContext } from '../../form-context';
 import styles from './form-page.scss';
 import { useTranslation } from 'react-i18next';
+import { isSectionExpanded } from '../../utils/form-page-utils';
 
 function FormPage({ page, onFieldChange, setSelectedPage, isFormExpanded }) {
   const { t } = useTranslation();
@@ -42,7 +43,7 @@ function FormPage({ page, onFieldChange, setSelectedPage, isFormExpanded }) {
           {visibleSections.map((section) => (
             <AccordionItem
               title={t(section.label)}
-              open={isFormExpanded !== undefined ? isFormExpanded : isTrue(section.isExpanded)}
+              open={isSectionExpanded(section, isFormExpanded)}
               className={styles.sectionContent}
               key={`section-${section.id}`}>
               <div className={styles.formSection}>

--- a/src/hooks/useFormCollapse.tsx
+++ b/src/hooks/useFormCollapse.tsx
@@ -1,8 +1,8 @@
-import { type SessionMode } from '../types';
+import type { FormExpanded, SessionMode } from '../types';
 import { useCallback, useEffect, useState } from 'react';
 
 export function useFormCollapse(sessionMode: SessionMode) {
-  const [isFormExpanded, setIsFormExpanded] = useState<boolean | undefined>(undefined);
+  const [isFormExpanded, setIsFormExpanded] = useState<FormExpanded>(undefined);
 
   const hideFormCollapseToggle = useCallback(() => {
     const HideFormCollapseToggle = new CustomEvent('openmrs:form-view-embedded', { detail: { value: false } });

--- a/src/hooks/useFormCollapse.tsx
+++ b/src/hooks/useFormCollapse.tsx
@@ -2,7 +2,7 @@ import { type SessionMode } from '../types';
 import { useCallback, useEffect, useState } from 'react';
 
 export function useFormCollapse(sessionMode: SessionMode) {
-  const [isFormExpanded, setIsFormExpanded] = useState(true);
+  const [isFormExpanded, setIsFormExpanded] = useState<boolean | undefined>(undefined);
 
   const hideFormCollapseToggle = useCallback(() => {
     const HideFormCollapseToggle = new CustomEvent('openmrs:form-view-embedded', { detail: { value: false } });

--- a/src/types.ts
+++ b/src/types.ts
@@ -471,3 +471,5 @@ export interface PatientProgramPayload {
     endDate?: string;
   }>;
 }
+
+export type FormExpanded = boolean | undefined;

--- a/src/utils/form-page-utils.ts
+++ b/src/utils/form-page-utils.ts
@@ -1,14 +1,13 @@
-import { FormSection } from 'src/types';
+import { type FormExpanded, type FormSection } from '../types';
 import { isTrue } from './boolean-utils';
 
-export function isSectionExpanded(section: FormSection, isFormExpanded): boolean {
-  let sectionIsExpanded = true;
-
+export function isSectionExpanded(section: FormSection, isFormExpanded: FormExpanded): FormExpanded {
   if (isFormExpanded !== undefined) {
-    sectionIsExpanded = isFormExpanded;
+    return isFormExpanded;
   }
-  if (!isTrue(section?.isExpanded)) {
-    if (section?.isExpanded !== undefined && section?.isExpanded !== null) sectionIsExpanded = false;
+
+  if (section?.isExpanded !== undefined && section?.isExpanded !== null) {
+    return isTrue(section.isExpanded);
   }
-  return sectionIsExpanded;
+  return true;
 }

--- a/src/utils/form-page-utils.ts
+++ b/src/utils/form-page-utils.ts
@@ -1,0 +1,14 @@
+import { FormSection } from 'src/types';
+import { isTrue } from './boolean-utils';
+
+export function isSectionExpanded(section: FormSection, isFormExpanded): boolean {
+  let sectionIsExpanded = true;
+
+  if (isFormExpanded !== undefined) {
+    sectionIsExpanded = isFormExpanded;
+  }
+  if (!isTrue(section?.isExpanded)) {
+    if (section?.isExpanded !== undefined && section?.isExpanded !== null) sectionIsExpanded = false;
+  }
+  return sectionIsExpanded;
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

This PR fixes the issue with forms not collapsing/expanding after configuring the `isExpanded` property within the schema.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/openmrs/openmrs-form-engine-lib/assets/51090527/86db74f6-443b-4600-a797-93fc57c8b98a

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3378

## Other
<!-- Anything not covered above -->
