### PR TITLE
(fix) O3-3377: error on bootstrapping attachment field on edit mode 

### DIFF
--- a/src/components/inputs/file/file.component.tsx
+++ b/src/components/inputs/file/file.component.tsx
@@ -9,6 +9,7 @@ import { createAttachment } from '../../../utils/common-utils';
 import { type FormFieldProps } from '../../../types';
 import { FormContext } from '../../../form-context';
 import { isInlineView } from '../../../utils/form-helper';
+import { isEmpty } from '../../../validators/form-validator';
 
 interface FileProps extends FormFieldProps {}
 type AllowedModes = 'uploader' | 'camera' | 'edit' | '';
@@ -39,7 +40,7 @@ const File: React.FC<FileProps> = ({ question, handler }) => {
 
   const attachmentValue = useMemo(() => {
     const firstValue = Object?.values(myInitVal)[0];
-    if (firstValue) {
+    if (!isEmpty(firstValue)) {
       const attachment = createAttachment(firstValue?.[0]);
       return attachment;
     }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR resolves the issue where the UI throws an error when trying to initialize an attachment field with an empty attachment value in edit mode.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3377

## Other
<!-- Anything not covered above -->
