### PR TITLE
(feat) O3-2491: Add support for a time picker

### DIFF
--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -121,39 +121,42 @@ const DateField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
     !question.isHidden && (
       <>
         <div className={styles.datetime}>
-          <div>
-            <Layer>
-              <OpenmrsDatePicker
-                id={question.id}
-                dateFormat={carbonDateFormat}
-                onChange={(date) => onDateChange([date])}
-                labelText={
-                  question.isRequired ? (
-                    <RequiredFieldLabel label={t(question.label)} />
-                  ) : (
-                    <span>{t(question.label)}</span>
-                  )
-                }
-                invalid={errors.length > 0}
-                invalidText={errors[0]?.message}
-                value={field.value}
-                disabled={question.isDisabled}
-                readonly={isTrue(question.readonly)}
-                carbonOptions={{
-                  placeholder: placeholder,
-                  warn: warnings[0]?.message,
-                  warnText: warnings[0]?.message,
-                  className: styles.boldedLabel,
-                  datePickerType: datePickerType,
-                }}
-              />
-            </Layer>
-          </div>
-          {question?.questionOptions.rendering === 'datetime' ? (
+          {(question.datePickerFormat === 'calendar' || question.datePickerFormat === 'both') && (
+            <div>
+              <Layer>
+                <OpenmrsDatePicker
+                  id={question.id}
+                  dateFormat={carbonDateFormat}
+                  onChange={(date) => onDateChange([date])}
+                  labelText={
+                    question.isRequired ? (
+                      <RequiredFieldLabel label={t(question.label)} />
+                    ) : (
+                      <span>{t(question.label)}</span>
+                    )
+                  }
+                  invalid={errors.length > 0}
+                  invalidText={errors[0]?.message}
+                  value={field.value}
+                  disabled={question.isDisabled}
+                  readonly={isTrue(question.readonly)}
+                  carbonOptions={{
+                    placeholder: placeholder,
+                    warn: warnings[0]?.message,
+                    warnText: warnings[0]?.message,
+                    className: styles.boldedLabel,
+                    datePickerType: datePickerType,
+                  }}
+                />
+              </Layer>
+            </div>
+          )}
+
+          {question.datePickerFormat === 'both' || question.datePickerFormat === 'timer' ? (
             <div className={styles.timePickerSpacing}>
               <Layer>
                 <TimePicker
-                  className={styles.boldedLabel}
+                  className={styles.boldedLabel && styles.timeInput}
                   id={question.id}
                   labelText={<RequiredFieldLabel label={t('time', 'Time')} />}
                   placeholder="HH:MM"

--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -69,7 +69,7 @@ const DateField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
     } else {
       const time = event.target.value;
       setTime(time);
-      const currentDateTime = field.value;
+      const currentDateTime = question.datePickerFormat === 'timer' ? new Date() : field.value;
       const splitTime = time.split(':');
       currentDateTime.setHours(splitTime[0] ?? '00', splitTime[1] ?? '00');
       setFieldValue(question.id, currentDateTime);
@@ -179,7 +179,7 @@ const DateField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
                   placeholder="HH:MM"
                   pattern="(1[012]|[1-9]):[0-5][0-9])$"
                   type="time"
-                  disabled={!field.value ? true : false}
+                  disabled={question.datePickerFormat === 'timer' ? question.isDisabled : !field.value ? true : false}
                   value={
                     time
                       ? time

--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -34,20 +34,18 @@ const DateField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
   }, [encounterContext.sessionMode, question.readonly, question.inlineRendering, layoutType, workspaceLayout]);
 
   const onDateChange = ([date]) => {
-    let refinedDate = date instanceof Date ? new Date(date.setHours(0, 0, 0, 0)) : date;
-    refinedDate = setTimeInStateToDate(refinedDate);
+    const refinedDate = date instanceof Date ? new Date(date.setHours(0, 0, 0, 0)) : new Date(date);
+    setTimeIfPresent(refinedDate, time);
     setFieldValue(question.id, refinedDate);
     onChange(question.id, refinedDate, setErrors, setWarnings);
     handler?.handleFieldSubmission(question, refinedDate, encounterContext);
   };
 
-  const setTimeInStateToDate = (date) => {
-    date = new Date(date);
+  const setTimeIfPresent = (date: Date, time: string) => {
     if (!isEmpty(time)) {
-      const splitTime = time.split(':');
-      date.setHours(splitTime[0] ?? '00', splitTime[1] ?? '00');
+      const [hours, minutes] = time.split(':').map(Number);
+      date.setHours(hours ?? 0, minutes ?? 0);
     }
-    return date;
   };
 
   useEffect(() => {
@@ -69,12 +67,11 @@ const DateField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
     } else {
       const time = event.target.value;
       setTime(time);
-      const currentDateTime = question.datePickerFormat === 'timer' ? new Date() : field.value;
-      const splitTime = time.split(':');
-      currentDateTime.setHours(splitTime[0] ?? '00', splitTime[1] ?? '00');
-      setFieldValue(question.id, currentDateTime);
-      onChange(question.id, currentDateTime, setErrors, setWarnings);
-      handler?.handleFieldSubmission(question, currentDateTime, encounterContext);
+      const dateValue = question.datePickerFormat === 'timer' ? new Date() : field.value;
+      setTimeIfPresent(dateValue, time);
+      setFieldValue(question.id, dateValue);
+      onChange(question.id, dateValue, setErrors, setWarnings);
+      handler?.handleFieldSubmission(question, dateValue, encounterContext);
     }
   };
 

--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { useField } from 'formik';
 import { Layer, TimePicker } from '@carbon/react';
+import classNames from 'classnames';
 import { type FormFieldProps } from '../../../types';
 import { isTrue } from '../../../utils/boolean-utils';
 import { isInlineView } from '../../../utils/form-helper';
@@ -122,7 +123,7 @@ const DateField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
       <>
         <div className={styles.datetime}>
           {(question.datePickerFormat === 'calendar' || question.datePickerFormat === 'both') && (
-            <div>
+            <div className={styles.datePickerSpacing}>
               <Layer>
                 <OpenmrsDatePicker
                   id={question.id}
@@ -153,10 +154,10 @@ const DateField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
           )}
 
           {question.datePickerFormat === 'both' || question.datePickerFormat === 'timer' ? (
-            <div className={styles.timePickerSpacing}>
+            <div>
               <Layer>
                 <TimePicker
-                  className={styles.boldedLabel && styles.timeInput}
+                  className={classNames(styles.boldedLabel, styles.timeInput)}
                   id={question.id}
                   labelText={<RequiredFieldLabel label={t('time', 'Time')} />}
                   placeholder="HH:MM"

--- a/src/components/inputs/date/date.scss
+++ b/src/components/inputs/date/date.scss
@@ -19,3 +19,13 @@
     margin-left: 1rem;
   }
 }
+
+.timeInput {
+  width: auto;
+  :hover {
+    cursor: text;
+  }
+  :focus {
+    cursor: text;
+  }
+}

--- a/src/components/inputs/date/date.scss
+++ b/src/components/inputs/date/date.scss
@@ -15,8 +15,8 @@
   flex-direction: row;
   flex-wrap: wrap;
 
-  > .timePickerSpacing {
-    margin-left: 1rem;
+  > .datePickerSpacing {
+    margin-right: 1rem;
   }
 }
 

--- a/src/components/inputs/unspecified/unspecified.test.tsx
+++ b/src/components/inputs/unspecified/unspecified.test.tsx
@@ -10,6 +10,7 @@ import { ObsSubmissionHandler } from '../../../submission-handlers/obsHandler';
 const question: FormField = {
   label: 'Visit Date',
   type: 'obs',
+  datePickerFormat: 'calendar',
   questionOptions: {
     rendering: 'date',
     concept: '163260AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
@@ -35,7 +36,7 @@ const encounterContext: EncounterContext = {
   setEncounterProvider: jest.fn,
   setEncounterLocation: jest.fn,
   encounterRole: '8cb3a399-d18b-4b62-aefb-5a0f948a3809',
-  setEncounterRole: jest.fn
+  setEncounterRole: jest.fn,
 };
 
 const renderForm = (initialValues) => {

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -524,7 +524,7 @@ describe('Form engine component', () => {
 
       await user.click(dateOfBirth);
       await user.paste('2022-03-11T00:00:00.000Z');
-      await user.tab()
+      await user.tab();
 
       expect(dateOfBirth).toHaveValue('11/03/2022');
 

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -94,7 +94,9 @@ describe('Form engine component', () => {
   });
 
   it('should render by the form UUID without dying', async () => {
-    renderForm('955ab92f-f93e-4dc0-9c68-b7b2346def55', null);
+    await act(async () => {
+      renderForm('955ab92f-f93e-4dc0-9c68-b7b2346def55', null);
+    });
 
     await assertFormHasAllFields(screen, [
       { fieldName: 'When was the HIV test conducted? *', fieldType: 'date' },

--- a/src/submission-handlers/obsHandler.test.ts
+++ b/src/submission-handlers/obsHandler.test.ts
@@ -20,7 +20,7 @@ const encounterContext: EncounterContext = {
   setEncounterProvider: jest.fn,
   setEncounterLocation: jest.fn,
   encounterRole: '',
-  setEncounterRole: jest.fn
+  setEncounterRole: jest.fn,
 };
 
 describe('ObsSubmissionHandler - handleFieldSubmission', () => {
@@ -133,6 +133,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     const field: FormField = {
       label: 'HTS Date',
       type: 'obs',
+      datePickerFormat: 'calendar',
       questionOptions: {
         rendering: 'date',
         concept: 'j8b6705b-b6d8-4eju-8f37-0b14f5347569',
@@ -315,6 +316,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     const field: FormField = {
       label: 'HTS date',
       type: 'obs',
+      datePickerFormat: 'calendar',
       questionOptions: {
         rendering: 'date',
         concept: '3e432ad5-7b19-4866-a68f-abf0d9f52a01',
@@ -470,6 +472,7 @@ describe('ObsSubmissionHandler - handleFieldSubmission', () => {
     const field: FormField = {
       label: 'HTS date',
       type: 'obs',
+      datePickerFormat: 'calendar',
       questionOptions: {
         rendering: 'date',
         concept: '3e432ad5-7b19-4866-a68f-abf0d9f52a01',
@@ -594,6 +597,7 @@ describe('ObsSubmissionHandler - getInitialValue', () => {
     const field: FormField = {
       label: 'HTS Date',
       type: 'obs',
+      datePickerFormat: 'calendar',
       questionOptions: {
         rendering: 'date',
         concept: 'j8b6705b-b6d8-4eju-8f37-0b14f5347569',
@@ -753,6 +757,7 @@ describe('hasPreviousObsValueChanged', () => {
   });
   it('should support date values', () => {
     const dateField = {
+      datePickerFormat: 'calendar',
       questionOptions: {
         rendering: 'date',
       },
@@ -767,6 +772,7 @@ describe('hasPreviousObsValueChanged', () => {
   });
   it('should support datetime values', () => {
     const dateTimeField = {
+      datePickerFormat: 'both',
       questionOptions: {
         rendering: 'datetime',
       },

--- a/src/submission-handlers/obsHandler.ts
+++ b/src/submission-handlers/obsHandler.ts
@@ -140,11 +140,17 @@ function editObs(field: FormField, newValue: any) {
 }
 
 function formatDate(field: FormField, value: Date) {
-  if (hasRendering(field, 'date')) {
-    return dayjs(value).format('YYYY-MM-DD');
-  }
-  if (hasRendering(field, 'datetime')) {
-    return dayjs(value).format('YYYY-MM-DD HH:mm');
+  if (field.datePickerFormat) {
+    switch (field.datePickerFormat) {
+      case 'calendar':
+        return dayjs(value).format('YYYY-MM-DD');
+      case 'timer':
+        return dayjs(value).format('HH:mm');
+      case 'both':
+        return dayjs(value).format('YYYY-MM-DD HH:mm');
+      default:
+        return dayjs(value).format('YYYY-MM-DD');
+    }
   }
   return value;
 }

--- a/src/transformers/default-schema-transformer.ts
+++ b/src/transformers/default-schema-transformer.ts
@@ -151,7 +151,7 @@ function transformByRendering(question: FormField) {
       question.datePickerFormat = question.datePickerFormat ?? 'calendar';
       break;
     case 'datetime':
-      question.datePickerFormat = 'both';
+      question.datePickerFormat = question.datePickerFormat ?? 'both';
       break;
   }
   return question;

--- a/src/transformers/default-schema-transformer.ts
+++ b/src/transformers/default-schema-transformer.ts
@@ -149,6 +149,10 @@ function transformByRendering(question: FormField) {
       break;
     case 'date':
       question.datePickerFormat = question.datePickerFormat ?? 'calendar';
+      break;
+    case 'datetime':
+      question.datePickerFormat = 'both';
+      break;
   }
   return question;
 }

--- a/src/transformers/default-schema-transformer.ts
+++ b/src/transformers/default-schema-transformer.ts
@@ -147,6 +147,8 @@ function transformByRendering(question: FormField) {
     case 'group':
       handleLabOrders(question);
       break;
+    case 'date':
+      question.datePickerFormat = question.datePickerFormat ?? 'calendar';
   }
   return question;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,7 @@ export interface FormField {
   label: string;
   type: string;
   questionOptions: FormQuestionOptions;
+  datePickerFormat?: 'both' | 'calendar' | 'timer';
   id: string;
   groupId?: string;
   questions?: Array<FormField>;
@@ -262,6 +263,7 @@ export type RenderType =
   | 'content-switcher'
   | 'date'
   | 'datetime'
+  | 'time'
   | 'encounter-location'
   | 'encounter-provider'
   | 'encounter-role'

--- a/src/types.ts
+++ b/src/types.ts
@@ -263,7 +263,6 @@ export type RenderType =
   | 'content-switcher'
   | 'date'
   | 'datetime'
-  | 'time'
   | 'encounter-location'
   | 'encounter-provider'
   | 'encounter-role'


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR aims to support the rendering of a time picker alongside the date picker based on the prop `datePickerFormat`. If the prop is null, only the date picker will be displayed.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1440" alt="Screenshot 2024-06-07 at 5 24 30 PM" src="https://github.com/openmrs/openmrs-form-engine-lib/assets/34070216/3981b0d6-42fa-4edb-b61d-0f1703690c11">


**Submitting values**

https://github.com/openmrs/openmrs-form-engine-lib/assets/34070216/6d9f844b-3b3b-4574-ac9e-d3af8fa29cc5


**Editing time**

https://github.com/openmrs/openmrs-form-engine-lib/assets/34070216/f17c41cb-7523-41d2-baab-3a0ce9030776

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
[JIRA ticket](https://issues.openmrs.org/browse/O3-2491)

## Other
<!-- Anything not covered above -->
[PR to update prop name](https://github.com/openmrs/openmrs-esm-form-builder/pull/290)
