### PR TITLE
(fix) O3-2252: Calculated values shouldn't be overwritten by the Encounter's values

### DIFF
--- a/__mocks__/use-initial-values/encounter.mock.json
+++ b/__mocks__/use-initial-values/encounter.mock.json
@@ -798,6 +798,74 @@
         }
       ],
       "resourceVersion": "2.1"
+    },
+    {
+      "uuid": "30f1206c-4354-4deb-9cfa-bcb18e934144",
+      "obsDatetime": "2024-06-11T11:43:33.000+0000",
+      "comment": null,
+      "voided": false,
+      "groupMembers": null,
+      "formFieldNamespace": "rfe-forms",
+      "formFieldPath": "rfe-forms-height",
+      "concept": {
+        "uuid": "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "name": {
+          "uuid": "d17c467f-e5c1-30dc-b916-e7d5f9a8935a",
+          "name": "Height (cm)"
+        }
+      },
+      "value": 176.0
+    },
+    {
+      "uuid": "037aaaca-14f1-460c-bc59-579817569794",
+      "obsDatetime": "2024-06-11T11:43:33.000+0000",
+      "comment": null,
+      "voided": false,
+      "groupMembers": null,
+      "formFieldNamespace": "rfe-forms",
+      "formFieldPath": "rfe-forms-weight",
+      "concept": {
+        "uuid": "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "name": {
+          "uuid": "c1015fd1-729b-33c7-82e8-0b14a5a824ed",
+          "name": "Weight (kg)"
+        }
+      },
+      "value": 56.0
+    },
+    {
+      "uuid": "5c281bdc-3798-4d18-b780-34e177e2fdb4",
+      "obsDatetime": "2024-06-11T11:43:33.000+0000",
+      "comment": null,
+      "voided": false,
+      "groupMembers": null,
+      "formFieldNamespace": "rfe-forms",
+      "formFieldPath": "rfe-forms-bmi",
+      "concept": {
+        "uuid": "1342AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "name": {
+          "uuid": "1431BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          "name": "Body mass index"
+        }
+      },
+      "value": 2
+    },
+    {
+      "uuid": "50729006-9b87-4bfb-80c0-4c53379b49a7",
+      "obsDatetime": "2024-06-26T14:51:42.000+0000",
+      "comment": null,
+      "voided": false,
+      "groupMembers": null,
+      "formFieldNamespace": "rfe-forms",
+      "formFieldPath": "rfe-forms-bodyWeight",
+      "concept": {
+        "uuid": "159428AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "name": {
+          "uuid": "106514BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          "name": "Weight percentile"
+        }
+      },
+      "valueNumeric": 2
     }
   ],
   "orders": [


### PR DESCRIPTION
… values

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR resolves the issue of null or undefined initial values for calculated fields when entering edit mode. Previously, the assumption was that all calculated fields would be retrieved through asynchronous functions from the expression runner. This assumption led to problems when synchronous functions were used, resulting in null or undefined initial values.


## Screenshots
<!-- Required if you are making UI changes. -->
https://www.loom.com/share/866edea9d4c34b91ab4ef3ef93eba49c?sid=7ffa7c0d-58cd-42e2-a30f-64d4448462d7

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
