### PR TITLE
(fix)03:3407 Fix styling of single-page forms in a maximized workspace

### DIFF
--- a/src/form-engine.scss
+++ b/src/form-engine.scss
@@ -42,7 +42,11 @@
 .contentBody {
   overflow-y: auto;
   width: inherit;
-  position: sticky;
+  position: relative;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
 }
 
 .minifiedButtons {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
 PR addresses styling of single-page forms in a maximized workspace ie content to be aligned at the top

## Screenshots
https://www.loom.com/share/6635a174b3044555b0a8463f17475aa3
## Related Issue
https://openmrs.atlassian.net/browse/O3-3407

## Other
<!-- Anything not covered above -->
