### PR TITLE
(fix) O3-3337 - Support expressions that don't use whitespace as delimiters

### DIFF
--- a/src/utils/expression-parser.test.ts
+++ b/src/utils/expression-parser.test.ts
@@ -7,8 +7,14 @@ import {
   linkReferencedFieldValues,
   parseExpression,
   replaceFieldRefWithValuePath,
+  expressionFormatter,
 } from './expression-parser';
 import { testFields } from './expression-runner.test';
+
+const testFieldValues = {
+  patientIdentificationNumber: 'test value 1',
+  linkedToCare: 'test value 2',
+};
 
 describe('Expression parsing', () => {
   it('should split expression 1 into parts correctly', () => {
@@ -304,5 +310,38 @@ describe('hasParentheses', () => {
   it('should return true for complex expression with multiple types of parentheses', () => {
     const expression = 'func1(arg1, (func2(arg2) && func3(arg3)))';
     expect(hasParentheses(expression)).toBe(true);
+  });
+});
+
+describe('expression formatter function', () => {
+  it('should replace the field id with fieldValue.field id for all form fields', () => {
+    const expressionA = "linkedToCare!=='a8aaf3e2-1350-11df-a1f1-0026b9348838";
+    const expressionB = 'patientIdentificationNumber+linkedToCare';
+    const expressionC = "patientIdentificationNumber== 'a8aaf3e2-1350-11df-a1f1-0026b9348838";
+    const expressionD =
+      "!isEmpty(referredToPreventionServices)&&isEmpty(myValue) && (bodyTemperature==='a890d1ba-1350-11df-a1f1-0026b9348838')";
+
+    const testFieldValues = {
+      patientIdentificationNumber: 'test value 1',
+      linkedToCare: 'test value 2',
+      bodyTemperature: 'test value 3',
+      referredToPreventionServices: 'test value 4',
+    };
+
+    expect(expressionFormatter(expressionA, testFields, testFieldValues)).toBe(
+      "fieldValues.linkedToCare!=='a8aaf3e2-1350-11df-a1f1-0026b9348838",
+    );
+
+    expect(expressionFormatter(expressionB, testFields, testFieldValues)).toBe(
+      'fieldValues.patientIdentificationNumber+fieldValues.linkedToCare',
+    );
+
+    expect(expressionFormatter(expressionC, testFields, testFieldValues)).toBe(
+      "fieldValues.patientIdentificationNumber== 'a8aaf3e2-1350-11df-a1f1-0026b9348838",
+    );
+
+    expect(expressionFormatter(expressionD, testFields, testFieldValues)).toBe(
+      "!isEmpty(fieldValues.referredToPreventionServices)&&isEmpty(myValue) && (fieldValues.bodyTemperature==='a890d1ba-1350-11df-a1f1-0026b9348838')",
+    );
   });
 });

--- a/src/utils/expression-parser.test.ts
+++ b/src/utils/expression-parser.test.ts
@@ -314,7 +314,7 @@ describe('hasParentheses', () => {
 });
 
 describe('expression formatter function', () => {
-  it('should replace the field id with fieldValue.field id for all form fields', () => {
+  it('should not care about whether there are spaces around operators', () => {
     const expressionA = "linkedToCare!=='a8aaf3e2-1350-11df-a1f1-0026b9348838";
     const expressionB = 'patientIdentificationNumber+linkedToCare';
     const expressionC = "patientIdentificationNumber== 'a8aaf3e2-1350-11df-a1f1-0026b9348838";

--- a/src/utils/expression-parser.ts
+++ b/src/utils/expression-parser.ts
@@ -156,3 +156,21 @@ function findReferencedFieldIfExists(fieldId: string, fields: FormField[]): Form
   }
   return fields.find((field) => field.id === fieldId);
 }
+
+export function expressionFormatter(expression: string, fields: FormField[], fieldValues: Record<string, any>) {
+  const matchedFields = [];
+  let formattedExpression = expression;
+
+  fields.forEach((field) => {
+    if (expression.includes(field.id) && !expression.includes(`fieldValues.${field.id}`)) {
+      matchedFields.push(field);
+    }
+  });
+
+  if (matchedFields?.length) {
+    matchedFields.forEach((field) => {
+      formattedExpression = replaceFieldRefWithValuePath(field, fieldValues[field.id], expression);
+    });
+  }
+  return formattedExpression;
+}

--- a/src/utils/expression-parser.ts
+++ b/src/utils/expression-parser.ts
@@ -157,7 +157,7 @@ function findReferencedFieldIfExists(fieldId: string, fields: FormField[]): Form
   return fields.find((field) => field.id === fieldId);
 }
 
-export function expressionFormatter(expression: string, fields: FormField[], fieldValues: Record<string, any>) {
+export function expressionFormatter(expression: string, fields: FormField[], fieldValues: Record<string, any>): string {
   const matchedFields = [];
   let formattedExpression = expression;
 
@@ -169,7 +169,7 @@ export function expressionFormatter(expression: string, fields: FormField[], fie
 
   if (matchedFields?.length) {
     matchedFields.forEach((field) => {
-      formattedExpression = replaceFieldRefWithValuePath(field, fieldValues[field.id], expression);
+      formattedExpression = replaceFieldRefWithValuePath(field, fieldValues[field.id], formattedExpression);
     });
   }
   return formattedExpression;

--- a/src/utils/expression-runner.ts
+++ b/src/utils/expression-runner.ts
@@ -2,7 +2,12 @@ import { getRegisteredExpressionHelpers } from '../registry/registry';
 import { isEmpty } from 'lodash-es';
 import { type OpenmrsEncounter, type FormField, type FormPage, type FormSection } from '../types';
 import { CommonExpressionHelpers } from './common-expression-helpers';
-import { findAndRegisterReferencedFields, linkReferencedFieldValues, parseExpression } from './expression-parser';
+import {
+  expressionFormatter,
+  findAndRegisterReferencedFields,
+  linkReferencedFieldValues,
+  parseExpression,
+} from './expression-parser';
 import { HistoricalDataSourceService } from '../datasources/historical-data-source';
 import { type Visit } from '@openmrs/esm-framework';
 
@@ -75,7 +80,7 @@ export function evaluateExpression(
     _,
   };
 
-  expression = linkReferencedFieldValues(fields, fieldValues, parts);
+  expression = expressionFormatter(linkReferencedFieldValues(fields, fieldValues, parts), fields, fieldValues);
 
   try {
     return evaluate(expression, expressionContext);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR introduces a fix for various failing expression evaluations due to improper formatting during form construction.
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-3337

<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
