### PR TITLE
(feat) O3-3481 Adds option to display multi-checkbox inline

### DIFF
--- a/src/components/inputs/multi-select/multi-select.component.tsx
+++ b/src/components/inputs/multi-select/multi-select.component.tsx
@@ -108,25 +108,7 @@ const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
       <>
         <div className={styles.boldedLabel}>
           <Layer>
-            {question.questionOptions.answers?.length > 5 ? (
-              <FilterableMultiSelect
-                placeholder={t('search', 'Search') + '...'}
-                onChange={handleSelectItemsChange}
-                id={t(question.label)}
-                items={selectOptions}
-                initialSelectedItems={initiallySelectedQuestionItems}
-                label={''}
-                titleText={label}
-                key={counter}
-                itemToString={(item) => (item ? item.label : ' ')}
-                disabled={question.isDisabled}
-                invalid={errors.length > 0}
-                invalidText={errors[0]?.message}
-                warn={warnings.length > 0}
-                warnText={warnings[0]?.message}
-                readOnly={question.readonly}
-              />
-            ) : (
+            {question.inlineMultiCheckbox ? (
               <CheckboxGroup legendText={label} name={question.id}>
                 {question.questionOptions.answers?.map((value, index) => {
                   return (
@@ -146,6 +128,24 @@ const MultiSelect: React.FC<FormFieldProps> = ({ question, onChange, handler, pr
                   );
                 })}
               </CheckboxGroup>
+            ) : (
+              <FilterableMultiSelect
+                placeholder={t('search', 'Search') + '...'}
+                onChange={handleSelectItemsChange}
+                id={t(question.label)}
+                items={selectOptions}
+                initialSelectedItems={initiallySelectedQuestionItems}
+                label={''}
+                titleText={label}
+                key={counter}
+                itemToString={(item) => (item ? item.label : ' ')}
+                disabled={question.isDisabled}
+                invalid={errors.length > 0}
+                invalidText={errors[0]?.message}
+                warn={warnings.length > 0}
+                warnText={warnings[0]?.message}
+                readOnly={question.readonly}
+              />
             )}
           </Layer>
         </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,7 @@ export interface FormField {
   questionInfo?: string;
   historicalExpression?: string;
   constrainMaxWidth?: boolean;
+  inlineMultiCheckbox?: boolean;
   meta?: QuestionMetaProps;
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Switches from constraining inline display of multi-select from number of answers to using config.  Previously the limit was less than 5 answers but with this users have the choice to dictate their preference. This requirement also matches behavior from other engines.  

**Sample Usage** 
Add `inlineMultiCheckbox` key to your already existing multi-checkbox fields

```
{
  "label": "Sample Section",
  "isExpanded": "true",
  "questions": [
     {
       "label": "Inline multi-checkbox",
       "type": "obs",
       "required": false,
       "id": "anotherSampleQuestion",
       "questionOptions": {
         "rendering": "multiCheckbox",
         "concept": "xxxx",
         "answers": [...]
       },
       "inlineMultiCheckbox": true
     }
   ]
}
```


## Screenshots

https://github.com/openmrs/openmrs-form-engine-lib/assets/15266028/9c5f9e9a-a7c4-41c4-bc24-d8880a5a6b91

## Related Issue

https://openmrs.atlassian.net/browse/O3-3481

## Other
<!-- Anything not covered above -->
