### PR TITLE
(feat) O3-3444 - Disable an answer within a question referencing an answer within that same question

### DIFF
--- a/src/components/encounter/encounter-form.component.tsx
+++ b/src/components/encounter/encounter-form.component.tsx
@@ -611,6 +611,23 @@ const EncounterForm: React.FC<EncounterFormProps> = ({
       value = value ? ConceptTrue : ConceptFalse;
     }
 
+    if (codedTypes.includes(field.questionOptions.rendering)) {
+      field.questionOptions.answers.forEach((answer) => {
+        if (answer.disable?.disableWhenExpression) {
+          answer.disable.isDisabled = evaluateExpression(
+            answer.disable?.disableWhenExpression,
+            { value: field, type: 'field' },
+            fields,
+            { ...values, [fieldName]: value },
+            {
+              mode: sessionMode,
+              patient,
+            },
+          );
+        }
+      });
+    }
+
     if (field.fieldDependants) {
       field.fieldDependants.forEach((dep) => {
         const dependant = fields.find((f) => f.id == dep);

--- a/src/components/encounter/encounter-form.component.tsx
+++ b/src/components/encounter/encounter-form.component.tsx
@@ -613,7 +613,8 @@ const EncounterForm: React.FC<EncounterFormProps> = ({
 
     if (codedTypes.includes(field.questionOptions.rendering)) {
       field.questionOptions.answers.forEach((answer) => {
-        if (answer.disable?.disableWhenExpression) {
+        const disableExpression = answer.disable?.disableWhenExpression;
+        if (disableExpression && disableExpression.includes('myValue')) {
           answer.disable.isDisabled = evaluateExpression(
             answer.disable?.disableWhenExpression,
             { value: field, type: 'field' },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR introduces support for answers belonging to fields with `coded` type renderings to disable whenever you select an answer within the same field. 
## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/openmrs/openmrs-form-engine-lib/assets/51090527/77b2f30d-d09c-4f1d-8b00-a5e16ce19095


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3444
## Other
<!-- Anything not covered above -->
