### PR TITLE
(fix) O3-3532: Fix broken UI on collapsing and reopening form sections

### DIFF
--- a/src/components/page/form-page.scss
+++ b/src/components/page/form-page.scss
@@ -56,6 +56,11 @@
   background-color: colors.$gray-10;
 }
 
+// TODO: try removing this when upgrading @carbon/react. Added at 1.37
+:global(.cds--accordion__wrapper) {
+  max-block-size: unset !important;
+}
+
 @media (min-width: 640px) {
   :global(.cds--accordion__content) {
     padding-right: 2rem !important;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
UI was breaking when a form section would be collapsed and expanded again.

## Screenshots

https://github.com/openmrs/openmrs-form-engine-lib/assets/12844964/a8c5d282-661d-4b4b-80bc-1461f578a947



## Related Issue

https://openmrs.atlassian.net/issues/O3-3532

## Other
<!-- Anything not covered above -->
