### PR TITLE
(fix) Update form fetch request to return the latest form by uuid or name

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -4,7 +4,9 @@ import { type OpenmrsForm, type PatientIdentifier, type PatientProgramPayload } 
 import { isUuid } from '../utils/boolean-utils';
 
 export function saveEncounter(abortController: AbortController, payload, encounterUuid?: string) {
-  const url = encounterUuid ? `${restBaseUrl}/encounter/${encounterUuid}?v=${encounterRepresentation}` : `${restBaseUrl}/encounter?v=${encounterRepresentation}`;
+  const url = encounterUuid
+    ? `${restBaseUrl}/encounter/${encounterUuid}?v=${encounterRepresentation}`
+    : `${restBaseUrl}/encounter?v=${encounterRepresentation}`;
 
   return openmrsFetch(url, {
     headers: {
@@ -104,7 +106,7 @@ export async function fetchOpenMRSForm(nameOrUUID: string): Promise<OpenmrsForm 
     return openmrsFormResponse;
   }
   return openmrsFormResponse.results?.length
-    ? openmrsFormResponse.results[0]
+    ? openmrsFormResponse.results[openmrsFormResponse.results?.length - 1]
     : new Error(`Form with ${nameOrUUID} was not found`);
 }
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -105,8 +105,9 @@ export async function fetchOpenMRSForm(nameOrUUID: string): Promise<OpenmrsForm 
   if (isUUID) {
     return openmrsFormResponse;
   }
+
   return openmrsFormResponse.results?.length
-    ? openmrsFormResponse.results[openmrsFormResponse.results?.length - 1]
+    ? openmrsFormResponse.results.find((form) => form.retired === false)
     : new Error(`Form with ${nameOrUUID} was not found`);
 }
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
When fetching a form by name, the current form engine returns a list of forms with that name, including retired forms. Using the o3 forms endpoint, it is possible that the returned result might be a retired form. This PR ensures that the latest (most recent) form is fetched instead of the first item in the array, which could be a retired form.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
