### PR TITLE
Revert "(fix) O3-3337 - Support expressions that don't use whitespace as delimiters"

### DIFF
--- a/src/utils/expression-parser.test.ts
+++ b/src/utils/expression-parser.test.ts
@@ -7,14 +7,8 @@ import {
   linkReferencedFieldValues,
   parseExpression,
   replaceFieldRefWithValuePath,
-  expressionFormatter,
 } from './expression-parser';
 import { testFields } from './expression-runner.test';
-
-const testFieldValues = {
-  patientIdentificationNumber: 'test value 1',
-  linkedToCare: 'test value 2',
-};
 
 describe('Expression parsing', () => {
   it('should split expression 1 into parts correctly', () => {
@@ -310,38 +304,5 @@ describe('hasParentheses', () => {
   it('should return true for complex expression with multiple types of parentheses', () => {
     const expression = 'func1(arg1, (func2(arg2) && func3(arg3)))';
     expect(hasParentheses(expression)).toBe(true);
-  });
-});
-
-describe('expression formatter function', () => {
-  it('should not care about whether there are spaces around operators', () => {
-    const expressionA = "linkedToCare!=='a8aaf3e2-1350-11df-a1f1-0026b9348838";
-    const expressionB = 'patientIdentificationNumber+linkedToCare';
-    const expressionC = "patientIdentificationNumber== 'a8aaf3e2-1350-11df-a1f1-0026b9348838";
-    const expressionD =
-      "!isEmpty(referredToPreventionServices)&&isEmpty(myValue) && (bodyTemperature==='a890d1ba-1350-11df-a1f1-0026b9348838')";
-
-    const testFieldValues = {
-      patientIdentificationNumber: 'test value 1',
-      linkedToCare: 'test value 2',
-      bodyTemperature: 'test value 3',
-      referredToPreventionServices: 'test value 4',
-    };
-
-    expect(expressionFormatter(expressionA, testFields, testFieldValues)).toBe(
-      "fieldValues.linkedToCare!=='a8aaf3e2-1350-11df-a1f1-0026b9348838",
-    );
-
-    expect(expressionFormatter(expressionB, testFields, testFieldValues)).toBe(
-      'fieldValues.patientIdentificationNumber+fieldValues.linkedToCare',
-    );
-
-    expect(expressionFormatter(expressionC, testFields, testFieldValues)).toBe(
-      "fieldValues.patientIdentificationNumber== 'a8aaf3e2-1350-11df-a1f1-0026b9348838",
-    );
-
-    expect(expressionFormatter(expressionD, testFields, testFieldValues)).toBe(
-      "!isEmpty(fieldValues.referredToPreventionServices)&&isEmpty(myValue) && (fieldValues.bodyTemperature==='a890d1ba-1350-11df-a1f1-0026b9348838')",
-    );
   });
 });

--- a/src/utils/expression-parser.ts
+++ b/src/utils/expression-parser.ts
@@ -156,21 +156,3 @@ function findReferencedFieldIfExists(fieldId: string, fields: FormField[]): Form
   }
   return fields.find((field) => field.id === fieldId);
 }
-
-export function expressionFormatter(expression: string, fields: FormField[], fieldValues: Record<string, any>): string {
-  const matchedFields = [];
-  let formattedExpression = expression;
-
-  fields.forEach((field) => {
-    if (expression.includes(field.id) && !expression.includes(`fieldValues.${field.id}`)) {
-      matchedFields.push(field);
-    }
-  });
-
-  if (matchedFields?.length) {
-    matchedFields.forEach((field) => {
-      formattedExpression = replaceFieldRefWithValuePath(field, fieldValues[field.id], formattedExpression);
-    });
-  }
-  return formattedExpression;
-}

--- a/src/utils/expression-runner.ts
+++ b/src/utils/expression-runner.ts
@@ -2,12 +2,7 @@ import { getRegisteredExpressionHelpers } from '../registry/registry';
 import { isEmpty } from 'lodash-es';
 import { type OpenmrsEncounter, type FormField, type FormPage, type FormSection } from '../types';
 import { CommonExpressionHelpers } from './common-expression-helpers';
-import {
-  expressionFormatter,
-  findAndRegisterReferencedFields,
-  linkReferencedFieldValues,
-  parseExpression,
-} from './expression-parser';
+import { findAndRegisterReferencedFields, linkReferencedFieldValues, parseExpression } from './expression-parser';
 import { HistoricalDataSourceService } from '../datasources/historical-data-source';
 import { type Visit } from '@openmrs/esm-framework';
 
@@ -80,7 +75,7 @@ export function evaluateExpression(
     _,
   };
 
-  expression = expressionFormatter(linkReferencedFieldValues(fields, fieldValues, parts), fields, fieldValues);
+  expression = linkReferencedFieldValues(fields, fieldValues, parts);
 
   try {
     return evaluate(expression, expressionContext);


### PR DESCRIPTION
Reverts openmrs/openmrs-form-engine-lib#327