### PR TITLE
(fix): Timepicker should have question label

### DIFF
--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -128,9 +128,11 @@ const DateField: React.FC<FormFieldProps> = ({ question, onChange, handler, prev
                   id={question.id}
                   labelText={
                     question.isRequired ? (
-                      <RequiredFieldLabel label={t('time', 'Time')} />
+                      <RequiredFieldLabel
+                        label={question.datePickerFormat === 'timer' ? t(question.label) : t('time', 'Time')}
+                      />
                     ) : (
-                      <span>{t('time', 'Time')}</span>
+                      <span>{question.datePickerFormat === 'timer' ? t(question.label) : t('time', 'Time')}</span>
                     )
                   }
                   placeholder="HH:MM"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The time picker should display the question's label if it is not rendered along with the calendar. Before the fix, the time picker would just render the text 'Time' as the label.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1238" alt="Screenshot 2024-07-29 at 1 49 37 PM" src="https://github.com/user-attachments/assets/a5249565-9a29-40e2-8e3d-e5989d5698bf">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-3673

## Other
<!-- Anything not covered above -->
