### PR TITLE
(Fix) Ensure clearing slection for ui-extended-select

### DIFF
--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -18,7 +18,7 @@ import styles from './ui-select-extended.scss';
 
 const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChange, previousValue }) => {
   const { t } = useTranslation();
-  const [field] = useField(question.id);
+  const [field, meta, helpers] = useField(question.id);
   const { setFieldValue, encounterContext, layoutType, workspaceLayout } = React.useContext(FormContext);
   const [items, setItems] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -63,6 +63,13 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
       handler?.handleFieldSubmission(question, previousValue, encounterContext);
     }
   }, [previousValue]);
+
+  useEffect(() => {
+    if (field.value === null) {
+      helpers.setValue(null, false);
+      setSearchTerm('');
+    }
+  }, [field.value, helpers]);
 
   const debouncedSearch = debounce((searchterm, dataSource) => {
     setItems([]);
@@ -158,7 +165,7 @@ const UiSelectExtended: React.FC<FormFieldProps> = ({ question, handler, onChang
             titleText={question.isRequired ? <RequiredFieldLabel label={t(question.label)} /> : t(question.label)}
             items={items}
             itemToString={(item) => item?.display}
-            selectedItem={items.find((item) => item.uuid == field.value)}
+            selectedItem={field.value ? items.find((item) => item.uuid === field.value) : null}
             shouldFilterItem={({ item, inputValue }) => {
               if (!inputValue) {
                 // Carbon's initial call at component mount


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Updated UiSelectExtended component to properly clear the selected item in the ComboBox when the value is set to null.
- Added useEffect to listen for changes to field.value and reset the ComboBox selection and search term when field.value is null.
- Ensured Formik's internal state is also updated by using helpers.setValue(null, false).

## Screenshots

https://github.com/user-attachments/assets/b8ddd5a3-5d8e-4372-9096-f2b6467208f8

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
